### PR TITLE
docs(README): add Web Interface Guide to documentation table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Welcome to the official Decent Cloud documentation. This resource is designed to
 | Document                                          | Description                                         | Audience   |
 |---------------------------------------------------|-----------------------------------------------------|------------|
 | [Getting Started](getting-started.md)             | Quick setup for new users                           | Everyone   |
+| [Web Interface Guide](web-interface-guide.md)     | Complete guide to using the web interface           | Users      |
 | [Installation](installation.md)                   | Step-by-step installation guide                     | Everyone   |
 | [User Guide](user-guide.md)                       | Detailed instructions for platform users            | Users      |
 | [Mining and Validation](mining-and-validation.md) | Instructions for validators to participate          | Validators |


### PR DESCRIPTION
## Summary
- Added missing "Web Interface Guide" entry to the documentation table in docs/README.md
- Smoke ticket for coordinator ready-label assignment validation

## Test Plan
- [x] Verified file renders correctly in markdown preview
- [x] Link target exists in docs folder