### PR TITLE
fix(website): guard console.debug with dev-mode check

### DIFF
--- a/website/src/lib/utils/debug.test.ts
+++ b/website/src/lib/utils/debug.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('debugLog', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('calls console.debug in dev mode', async () => {
+		vi.stubEnv('DEV', true);
+		vi.resetModules();
+		const { debugLog } = await import('./debug');
+		const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+		debugLog('test message', { key: 'value' });
+		expect(spy).toHaveBeenCalledWith('test message', { key: 'value' });
+	});
+
+	it('does not call console.debug in production mode', async () => {
+		vi.stubEnv('DEV', false);
+		vi.resetModules();
+		const { debugLog } = await import('./debug');
+		const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+		debugLog('should not appear');
+		expect(spy).not.toHaveBeenCalled();
+	});
+});

--- a/website/src/lib/utils/debug.ts
+++ b/website/src/lib/utils/debug.ts
@@ -1,0 +1,8 @@
+/**
+ * Debug logging that is tree-shaken out of production builds.
+ */
+export function debugLog(message: string, ...args: unknown[]): void {
+	if (import.meta.env.DEV) {
+		console.debug(message, ...args);
+	}
+}

--- a/website/src/routes/dashboard/provider/sla/+page.svelte
+++ b/website/src/routes/dashboard/provider/sla/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
+	import { debugLog } from '$lib/utils/debug';
 	import AuthRequiredCard from '$lib/components/AuthRequiredCard.svelte';
 	import {
 		getProviderContracts,
@@ -124,7 +125,7 @@
 			slaConfig = await getProviderSlaUptimeConfig(signed.headers, providerHex);
 		} catch (e) {
 			// Config not found is not fatal - keep defaults
-			console.debug('SLA config not found, using defaults:', e);
+			debugLog('SLA config not found, using defaults:', e);
 		} finally {
 			slaConfigLoading = false;
 		}

--- a/website/src/routes/dashboard/rentals/[contract_id]/+page.svelte
+++ b/website/src/routes/dashboard/rentals/[contract_id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from "svelte";
 	import { page } from "$app/stores";
 	import { goto } from "$app/navigation";
+	import { debugLog } from "$lib/utils/debug";
 	import AuthRequiredCard from "$lib/components/AuthRequiredCard.svelte";
 	import {
 		getUserContracts,
@@ -328,7 +329,7 @@
 				try {
 					usage = await getContractUsage(contractId, headers);
 				} catch (e) {
-					console.debug("No usage data for contract:", e);
+					debugLog("No usage data for contract:", e);
 				}
 			}
 			lastRefresh = Date.now();
@@ -373,7 +374,7 @@
 					usage = await getContractUsage(contractId, headers);
 				} catch (e) {
 					// Usage not available is not an error
-					console.debug("No usage data for contract:", e);
+					debugLog("No usage data for contract:", e);
 				}
 
 				// Try to fetch recipe log
@@ -385,7 +386,7 @@
 					)).headers;
 					recipeLog = await getContractRecipeLog(contractId, logHeaders);
 				} catch (e) {
-					console.debug("No recipe log for contract:", e);
+					debugLog("No recipe log for contract:", e);
 				}
 
 				// Try to fetch and decrypt credentials for provisioned contracts
@@ -442,7 +443,7 @@
 			// Decrypt the credentials
 			decryptedPassword = await decryptCredentials(encryptedJson, secretKey);
 		} catch (e) {
-			console.debug("No credentials available:", e);
+			debugLog("No credentials available:", e);
 			// Don't show error - credentials may not be set for all contracts
 		} finally {
 			credentialsLoading = false;


### PR DESCRIPTION
## Summary
- Add `debugLog()` utility guarded by `import.meta.env.DEV` — Vite tree-shakes it out of production builds entirely
- Replace all 5 `console.debug` calls across 2 Svelte components with `debugLog()`
- Add tests covering dev-mode logging and production silence

Closes #115
