### PR TITLE
feat(#113): alert users when saved offering prices change

### DIFF
--- a/api/src/database/offerings.rs
+++ b/api/src/database/offerings.rs
@@ -152,6 +152,14 @@ pub struct Offering {
     pub created_at_ns: Option<i64>,
 }
 
+struct SavedOfferingPriceChange {
+    offer_name: String,
+    old_currency: String,
+    old_monthly_price: f64,
+    new_currency: String,
+    new_monthly_price: f64,
+}
+
 /// Pricing statistics for offerings matching given filters
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS, Object)]
 #[ts(export, export_to = "../../website/src/lib/types/generated/")]
@@ -1010,6 +1018,59 @@ impl Database {
         Ok(count.0)
     }
 
+    async fn notify_saved_offering_price_change(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        offering_id: i64,
+        change: &SavedOfferingPriceChange,
+    ) -> Result<()> {
+        if (change.old_monthly_price - change.new_monthly_price).abs() < 1e-9 {
+            return Ok(());
+        }
+
+        let saved_user_pubkeys = sqlx::query_scalar::<_, Vec<u8>>(
+            "SELECT user_pubkey FROM saved_offerings WHERE offering_id = $1",
+        )
+        .bind(offering_id)
+        .fetch_all(&mut **tx)
+        .await?;
+
+        if saved_user_pubkeys.is_empty() {
+            return Ok(());
+        }
+
+        let direction = if change.new_monthly_price < change.old_monthly_price {
+            "dropped"
+        } else {
+            "changed"
+        };
+        let title = format!("Saved offering price {}", direction);
+        let body = format!(
+            "{} changed from {} {:.2} to {} {:.2}.",
+            change.offer_name,
+            change.old_currency,
+            change.old_monthly_price,
+            change.new_currency,
+            change.new_monthly_price
+        );
+        let created_at = chrono::Utc::now().timestamp();
+
+        for user_pubkey in saved_user_pubkeys {
+            sqlx::query(
+                "INSERT INTO user_notifications (user_pubkey, type, title, body, contract_id, created_at) VALUES ($1, $2, $3, $4, NULL, $5)",
+            )
+            .bind(user_pubkey.as_slice())
+            .bind("saved_offering_price_change")
+            .bind(&title)
+            .bind(&body)
+            .bind(created_at)
+            .execute(&mut **tx)
+            .await?;
+        }
+
+        Ok(())
+    }
+
     /// Create a new offering
     pub async fn create_offering(&self, pubkey: &[u8], params: Offering) -> Result<i64> {
         // Validate required fields
@@ -1251,23 +1312,23 @@ impl Database {
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        // Verify ownership
-        let owner: Option<Vec<u8>> = sqlx::query_scalar!(
-            "SELECT pubkey FROM provider_offerings WHERE id = $1",
-            offering_db_id
+        // Verify ownership and capture the current price for notifications.
+        let existing_offering = sqlx::query_as::<_, (Vec<u8>, String, String, f64)>(
+            "SELECT pubkey, offer_name, currency, monthly_price FROM provider_offerings WHERE id = $1",
         )
+        .bind(offering_db_id)
         .fetch_optional(&mut *tx)
         .await?;
 
-        match owner {
+        let existing_offering = match existing_offering {
             None => return Err(anyhow::anyhow!("Offering not found")),
-            Some(owner_pubkey) if owner_pubkey != pubkey => {
+            Some((owner_pubkey, _, _, _)) if owner_pubkey != pubkey => {
                 return Err(anyhow::anyhow!(
                     "Unauthorized: You do not own this offering"
                 ))
             }
-            _ => {}
-        }
+            Some(existing_offering) => existing_offering,
+        };
 
         // Validate datacenter_country is a known ISO country code
         if !params.datacenter_country.is_empty()
@@ -1369,6 +1430,16 @@ impl Database {
             provisioner_config
         };
 
+        let (_, _, existing_currency, existing_monthly_price) = &existing_offering;
+        let price_changed = (*existing_monthly_price - monthly_price).abs() >= 1e-9;
+        let price_change = SavedOfferingPriceChange {
+            offer_name: offer_name.clone(),
+            old_currency: existing_currency.clone(),
+            old_monthly_price: *existing_monthly_price,
+            new_currency: currency.clone(),
+            new_monthly_price: monthly_price,
+        };
+
         sqlx::query!(
             r#"UPDATE provider_offerings SET
                 offering_id = $1, offer_name = $2, description = $3, product_page_url = $4,
@@ -1451,6 +1522,11 @@ impl Database {
         )
         .execute(&mut *tx)
         .await?;
+
+        if price_changed {
+            self.notify_saved_offering_price_change(&mut tx, offering_db_id, &price_change)
+                .await?;
+        }
 
         tx.commit().await?;
         Ok(())
@@ -1700,31 +1776,42 @@ impl Database {
 
         let mut tx = self.pool.begin().await?;
 
-        // Verify all offerings belong to this provider atomically
+        // Verify all offerings belong to this provider atomically and capture current prices.
         let id_placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("${}", i)).collect();
         let pubkey_placeholder = format!("${}", ids.len() + 1);
         let verify_query = format!(
-            "SELECT COUNT(*) FROM provider_offerings WHERE id IN ({}) AND pubkey = {}",
+            "SELECT id, offer_name, currency, monthly_price FROM provider_offerings WHERE id IN ({}) AND pubkey = {}",
             id_placeholders.join(","),
             pubkey_placeholder
         );
 
-        let mut verify_builder = sqlx::query_scalar::<_, i64>(&verify_query);
+        let mut verify_builder = sqlx::query_as::<_, (i64, String, String, f64)>(&verify_query);
         for id in &ids {
             verify_builder = verify_builder.bind(id);
         }
         verify_builder = verify_builder.bind(pubkey);
 
-        let count: i64 = verify_builder.fetch_one(&mut *tx).await?;
-        if count != ids.len() as i64 {
+        let existing_offerings = verify_builder.fetch_all(&mut *tx).await?;
+        if existing_offerings.len() != ids.len() {
             return Err(anyhow::anyhow!(
                 "Not all offerings belong to this provider or some IDs are invalid"
             ));
         }
 
+        let existing_offerings: HashMap<i64, (String, String, f64)> = existing_offerings
+            .into_iter()
+            .map(|(id, offer_name, currency, monthly_price)| {
+                (id, (offer_name, currency, monthly_price))
+            })
+            .collect();
+
         // Update each offering's price within the transaction
         let mut rows_affected = 0u64;
         for (id, price_e9s) in updates {
+            let (offer_name, currency, old_monthly_price) = existing_offerings
+                .get(id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Offering {} missing after ownership verification", id))?;
             let monthly_price = *price_e9s as f64 / 1_000_000_000.0;
             let result = sqlx::query!(
                 "UPDATE provider_offerings SET monthly_price = $1 WHERE id = $2",
@@ -1733,6 +1820,19 @@ impl Database {
             )
             .execute(&mut *tx)
             .await?;
+
+            if (old_monthly_price - monthly_price).abs() >= 1e-9 {
+                let price_change = SavedOfferingPriceChange {
+                    offer_name,
+                    old_currency: currency.clone(),
+                    old_monthly_price,
+                    new_currency: currency,
+                    new_monthly_price: monthly_price,
+                };
+                self.notify_saved_offering_price_change(&mut tx, *id, &price_change)
+                    .await?;
+            }
+
             rows_affected += result.rows_affected();
         }
 

--- a/api/src/database/offerings/tests.rs
+++ b/api/src/database/offerings/tests.rs
@@ -3369,6 +3369,86 @@ async fn test_unsave_nonexistent_is_ok() {
 }
 
 #[tokio::test]
+async fn test_update_offering_price_change_notifies_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x66u8; 32];
+    let user_a = vec![0x67u8; 32];
+    let user_b = vec![0x68u8; 32];
+
+    insert_test_offering(&db, 7, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(7);
+
+    db.save_offering(&user_a, offering_id)
+        .await
+        .expect("save for user_a should succeed");
+    db.save_offering(&user_b, offering_id)
+        .await
+        .expect("save for user_b should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.monthly_price = 12.5;
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    for user in [&user_a, &user_b] {
+        let notifications = db
+            .get_user_notifications(user, 10)
+            .await
+            .expect("get_user_notifications should succeed");
+        assert_eq!(notifications.len(), 1, "expected one price alert");
+        assert_eq!(
+            notifications[0].notification_type,
+            "saved_offering_price_change"
+        );
+        assert_eq!(notifications[0].title, "Saved offering price changed");
+        assert!(
+            notifications[0]
+                .body
+                .contains("Test Offer changed from USD 10.00 to USD 12.50."),
+            "unexpected notification body: {}",
+            notifications[0].body
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_update_offering_same_price_does_not_notify_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x69u8; 32];
+    let user = vec![0x6Au8; 32];
+
+    insert_test_offering(&db, 8, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(8);
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.offer_name = "Renamed Offer".to_string();
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert!(notifications.is_empty(), "same price should not notify");
+}
+
+#[tokio::test]
 async fn test_bulk_update_offering_prices_updates_all() {
     let db = setup_test_db().await;
     let pubkey = vec![0xAAu8; 32];
@@ -3412,6 +3492,65 @@ async fn test_bulk_update_offering_prices_updates_all() {
         (o3.monthly_price - 35.0).abs() < 1e-6,
         "expected 35.0, got {}",
         o3.monthly_price
+    );
+}
+
+#[tokio::test]
+async fn test_bulk_update_offering_prices_notifies_only_changed_saved_offerings() {
+    let db = setup_test_db().await;
+    let provider = vec![0xABu8; 32];
+    let changed_user = vec![0xACu8; 32];
+    let unchanged_user = vec![0xADu8; 32];
+
+    insert_test_offering(&db, 9, &provider, "US", 10.0).await;
+    insert_test_offering(&db, 10, &provider, "US", 20.0).await;
+    let changed_offering_id = test_id_to_db_id(9);
+    let unchanged_offering_id = test_id_to_db_id(10);
+
+    db.save_offering(&changed_user, changed_offering_id)
+        .await
+        .expect("save changed offering should succeed");
+    db.save_offering(&unchanged_user, unchanged_offering_id)
+        .await
+        .expect("save unchanged offering should succeed");
+
+    let rows = db
+        .bulk_update_offering_prices(
+            &provider,
+            &[
+                (changed_offering_id, 15_000_000_000i64),
+                (unchanged_offering_id, 20_000_000_000i64),
+            ],
+        )
+        .await
+        .expect("bulk update should succeed");
+
+    assert_eq!(rows, 2, "expected both rows to be updated");
+
+    let changed_notifications = db
+        .get_user_notifications(&changed_user, 10)
+        .await
+        .expect("get_user_notifications for changed user should succeed");
+    assert_eq!(changed_notifications.len(), 1, "changed offering should notify");
+    assert_eq!(
+        changed_notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert!(
+        changed_notifications[0]
+            .body
+            .contains("Test Offer changed from USD 10.00 to USD 15.00."),
+        "unexpected changed notification body: {}",
+        changed_notifications[0].body
+    );
+
+    let unchanged_notifications = db
+        .get_user_notifications(&unchanged_user, 10)
+        .await
+        .expect("get_user_notifications for unchanged user should succeed");
+    assert!(
+        unchanged_notifications.is_empty(),
+        "unchanged offering should not notify"
     );
 }
 


### PR DESCRIPTION
## Summary
- notify users through the existing notification feed when a saved offering's monthly price changes
- cover both single-offering updates and bulk price updates so provider-side price edits cannot bypass alerts
- add focused database tests for changed-price and unchanged-price paths

## Test Plan
- `export TEST_DATABASE_URL=\"$(scripts/detect-postgres.sh | cut -d= -f2-)\" && cargo test -p api database::offerings::tests::test_update_offering_price_change_notifies_saved_users -- --exact`
- `export TEST_DATABASE_URL=\"$(scripts/detect-postgres.sh | cut -d= -f2-)\" && cargo test -p api database::offerings::tests::test_update_offering_same_price_does_not_notify_saved_users -- --exact`
- `export TEST_DATABASE_URL=\"$(scripts/detect-postgres.sh | cut -d= -f2-)\" && cargo test -p api database::offerings::tests::test_bulk_update_offering_prices_notifies_only_changed_saved_offerings -- --exact`
- `cargo clippy -p api --tests -- -D warnings`
- attempted `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test`, both blocked by `ic-canister` build setup because `dfxvm` has no default `dfx` version configured in this environment