### PR TITLE
feat(#193): extend price-change alerts to setup_fee and usage-based pricing

### DIFF
--- a/api/src/database/offerings.rs
+++ b/api/src/database/offerings.rs
@@ -158,6 +158,19 @@ struct SavedOfferingPriceChange {
     old_monthly_price: f64,
     new_currency: String,
     new_monthly_price: f64,
+    old_setup_fee: f64,
+    new_setup_fee: f64,
+    old_price_per_unit: Option<f64>,
+    new_price_per_unit: Option<f64>,
+    old_overage_price_per_unit: Option<f64>,
+    new_overage_price_per_unit: Option<f64>,
+}
+
+fn opt_f64_changed(old: Option<f64>, new: Option<f64>) -> bool {
+    match (old, new) {
+        (Some(o), Some(n)) => (o - n).abs() >= 1e-9,
+        _ => false,
+    }
 }
 
 /// Pricing statistics for offerings matching given filters
@@ -1019,7 +1032,38 @@ impl Database {
         offering_id: i64,
         change: &SavedOfferingPriceChange,
     ) -> Result<()> {
-        if (change.old_monthly_price - change.new_monthly_price).abs() < 1e-9 {
+        let mut changes: Vec<String> = Vec::new();
+
+        if (change.old_monthly_price - change.new_monthly_price).abs() >= 1e-9 {
+            changes.push(format!(
+                "monthly_price from {} {:.2} to {} {:.2}",
+                change.old_currency, change.old_monthly_price,
+                change.new_currency, change.new_monthly_price
+            ));
+        }
+        if (change.old_setup_fee - change.new_setup_fee).abs() >= 1e-9 {
+            changes.push(format!(
+                "setup_fee from {} {:.2} to {} {:.2}",
+                change.old_currency, change.old_setup_fee,
+                change.new_currency, change.new_setup_fee
+            ));
+        }
+        if opt_f64_changed(change.old_price_per_unit, change.new_price_per_unit) {
+            changes.push(format!(
+                "price_per_unit from {} {:.2} to {} {:.2}",
+                change.old_currency, change.old_price_per_unit.unwrap(),
+                change.new_currency, change.new_price_per_unit.unwrap()
+            ));
+        }
+        if opt_f64_changed(change.old_overage_price_per_unit, change.new_overage_price_per_unit) {
+            changes.push(format!(
+                "overage_price_per_unit from {} {:.2} to {} {:.2}",
+                change.old_currency, change.old_overage_price_per_unit.unwrap(),
+                change.new_currency, change.new_overage_price_per_unit.unwrap()
+            ));
+        }
+
+        if changes.is_empty() {
             return Ok(());
         }
 
@@ -1034,20 +1078,27 @@ impl Database {
             return Ok(());
         }
 
-        let direction = if change.new_monthly_price < change.old_monthly_price {
+        let monthly_dropped = change.new_monthly_price < change.old_monthly_price;
+        let setup_dropped = change.new_setup_fee < change.old_setup_fee;
+        let ppu_dropped = change.old_price_per_unit
+            .zip(change.new_price_per_unit)
+            .is_some_and(|(o, n)| n < o);
+        let opu_dropped = change.old_overage_price_per_unit
+            .zip(change.new_overage_price_per_unit)
+            .is_some_and(|(o, n)| n < o);
+        let direction = if monthly_dropped || setup_dropped || ppu_dropped || opu_dropped {
             "dropped"
         } else {
             "changed"
         };
         let title = format!("Saved offering price {}", direction);
-        let body = format!(
-            "{} changed from {} {:.2} to {} {:.2}.",
-            change.offer_name,
-            change.old_currency,
-            change.old_monthly_price,
-            change.new_currency,
-            change.new_monthly_price
-        );
+
+        let body = if changes.len() == 1 {
+            format!("{}: {}.", change.offer_name, changes[0])
+        } else {
+            format!("{} pricing changed: {}.", change.offer_name, changes.join("; "))
+        };
+
         let created_at = chrono::Utc::now().timestamp();
 
         for user_pubkey in saved_user_pubkeys {
@@ -1308,8 +1359,8 @@ impl Database {
         let mut tx = self.pool.begin().await?;
 
         // Verify ownership and capture the current price for notifications.
-        let existing_offering = sqlx::query_as::<_, (Vec<u8>, String, String, f64)>(
-            "SELECT pubkey, offer_name, currency, monthly_price FROM provider_offerings WHERE id = $1",
+        let existing_offering = sqlx::query_as::<_, (Vec<u8>, String, String, f64, f64, Option<f64>, Option<f64>)>(
+            "SELECT pubkey, offer_name, currency, monthly_price, setup_fee, price_per_unit, overage_price_per_unit FROM provider_offerings WHERE id = $1",
         )
         .bind(offering_db_id)
         .fetch_optional(&mut *tx)
@@ -1317,7 +1368,7 @@ impl Database {
 
         let existing_offering = match existing_offering {
             None => return Err(anyhow::anyhow!("Offering not found")),
-            Some((owner_pubkey, _, _, _)) if owner_pubkey != pubkey => {
+            Some((owner_pubkey, _, _, _, _, _, _)) if owner_pubkey != pubkey => {
                 return Err(anyhow::anyhow!(
                     "Unauthorized: You do not own this offering"
                 ))
@@ -1425,14 +1476,23 @@ impl Database {
             provisioner_config
         };
 
-        let (_, _, existing_currency, existing_monthly_price) = &existing_offering;
-        let price_changed = (*existing_monthly_price - monthly_price).abs() >= 1e-9;
+        let (_, _, existing_currency, existing_monthly_price, existing_setup_fee, existing_price_per_unit, existing_overage_price_per_unit) = &existing_offering;
+        let price_changed = (*existing_monthly_price - monthly_price).abs() >= 1e-9
+            || (*existing_setup_fee - setup_fee).abs() >= 1e-9
+            || opt_f64_changed(*existing_price_per_unit, price_per_unit)
+            || opt_f64_changed(*existing_overage_price_per_unit, overage_price_per_unit);
         let price_change = SavedOfferingPriceChange {
             offer_name: offer_name.clone(),
             old_currency: existing_currency.clone(),
             old_monthly_price: *existing_monthly_price,
             new_currency: currency.clone(),
             new_monthly_price: monthly_price,
+            old_setup_fee: *existing_setup_fee,
+            new_setup_fee: setup_fee,
+            old_price_per_unit: *existing_price_per_unit,
+            new_price_per_unit: price_per_unit,
+            old_overage_price_per_unit: *existing_overage_price_per_unit,
+            new_overage_price_per_unit: overage_price_per_unit,
         };
 
         sqlx::query!(
@@ -1775,12 +1835,12 @@ impl Database {
         let id_placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("${}", i)).collect();
         let pubkey_placeholder = format!("${}", ids.len() + 1);
         let verify_query = format!(
-            "SELECT id, offer_name, currency, monthly_price FROM provider_offerings WHERE id IN ({}) AND pubkey = {}",
+            "SELECT id, offer_name, currency, monthly_price, setup_fee, price_per_unit, overage_price_per_unit FROM provider_offerings WHERE id IN ({}) AND pubkey = {}",
             id_placeholders.join(","),
             pubkey_placeholder
         );
 
-        let mut verify_builder = sqlx::query_as::<_, (i64, String, String, f64)>(&verify_query);
+        let mut verify_builder = sqlx::query_as::<_, (i64, String, String, f64, f64, Option<f64>, Option<f64>)>(&verify_query);
         for id in &ids {
             verify_builder = verify_builder.bind(id);
         }
@@ -1793,17 +1853,17 @@ impl Database {
             ));
         }
 
-        let existing_offerings: HashMap<i64, (String, String, f64)> = existing_offerings
+        let existing_offerings: HashMap<i64, (String, String, f64, f64, Option<f64>, Option<f64>)> = existing_offerings
             .into_iter()
-            .map(|(id, offer_name, currency, monthly_price)| {
-                (id, (offer_name, currency, monthly_price))
+            .map(|(id, offer_name, currency, monthly_price, setup_fee, price_per_unit, overage_price_per_unit)| {
+                (id, (offer_name, currency, monthly_price, setup_fee, price_per_unit, overage_price_per_unit))
             })
             .collect();
 
         // Update each offering's price within the transaction
         let mut rows_affected = 0u64;
         for (id, price_e9s) in updates {
-            let (offer_name, currency, old_monthly_price) = existing_offerings
+            let (offer_name, currency, old_monthly_price, old_setup_fee, old_price_per_unit, old_overage_price_per_unit) = existing_offerings
                 .get(id)
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("Offering {} missing after ownership verification", id))?;
@@ -1823,6 +1883,12 @@ impl Database {
                     old_monthly_price,
                     new_currency: currency,
                     new_monthly_price: monthly_price,
+                    old_setup_fee,
+                    new_setup_fee: old_setup_fee,
+                    old_price_per_unit,
+                    new_price_per_unit: old_price_per_unit,
+                    old_overage_price_per_unit,
+                    new_overage_price_per_unit: old_overage_price_per_unit,
                 };
                 self.notify_saved_offering_price_change(&mut tx, *id, &price_change)
                     .await?;

--- a/api/src/database/offerings/tests.rs
+++ b/api/src/database/offerings/tests.rs
@@ -3410,7 +3410,7 @@ async fn test_update_offering_price_change_notifies_saved_users() {
         assert!(
             notifications[0]
                 .body
-                .contains("Test Offer changed from USD 10.00 to USD 12.50."),
+                .contains("Test Offer: monthly_price from USD 10.00 to USD 12.50."),
             "unexpected notification body: {}",
             notifications[0].body
         );
@@ -3446,6 +3446,210 @@ async fn test_update_offering_same_price_does_not_notify_saved_users() {
         .await
         .expect("get_user_notifications should succeed");
     assert!(notifications.is_empty(), "same price should not notify");
+}
+
+#[tokio::test]
+async fn test_update_offering_setup_fee_change_notifies_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x70u8; 32];
+    let user = vec![0x71u8; 32];
+
+    insert_test_offering(&db, 11, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(11);
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.setup_fee = 25.0;
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert_eq!(notifications.len(), 1, "expected one setup_fee alert");
+    assert_eq!(
+        notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert!(
+        notifications[0]
+            .body
+            .contains("Test Offer: setup_fee from USD 0.00 to USD 25.00."),
+        "unexpected notification body: {}",
+        notifications[0].body
+    );
+}
+
+#[tokio::test]
+async fn test_update_offering_price_per_unit_change_notifies_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x72u8; 32];
+    let user = vec![0x73u8; 32];
+
+    insert_test_offering(&db, 12, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(12);
+
+    // Set initial usage-based pricing
+    sqlx::query(
+        "UPDATE provider_offerings SET price_per_unit = 0.50, overage_price_per_unit = 1.00, pricing_model = 'usage_overage' WHERE id = $1",
+    )
+    .bind(offering_id)
+    .execute(&db.pool)
+    .await
+    .expect("set initial usage pricing");
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.price_per_unit = Some(0.75);
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert_eq!(notifications.len(), 1, "expected one price_per_unit alert");
+    assert_eq!(
+        notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert!(
+        notifications[0]
+            .body
+            .contains("Test Offer: price_per_unit from USD 0.50 to USD 0.75."),
+        "unexpected notification body: {}",
+        notifications[0].body
+    );
+}
+
+#[tokio::test]
+async fn test_update_offering_overage_price_per_unit_change_notifies_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x74u8; 32];
+    let user = vec![0x75u8; 32];
+
+    insert_test_offering(&db, 13, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(13);
+
+    sqlx::query(
+        "UPDATE provider_offerings SET price_per_unit = 0.50, overage_price_per_unit = 1.00, pricing_model = 'usage_overage' WHERE id = $1",
+    )
+    .bind(offering_id)
+    .execute(&db.pool)
+    .await
+    .expect("set initial usage pricing");
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.overage_price_per_unit = Some(1.50);
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert_eq!(notifications.len(), 1, "expected one overage alert");
+    assert_eq!(
+        notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert!(
+        notifications[0]
+            .body
+            .contains("Test Offer: overage_price_per_unit from USD 1.00 to USD 1.50."),
+        "unexpected notification body: {}",
+        notifications[0].body
+    );
+}
+
+#[tokio::test]
+async fn test_update_offering_multiple_price_changes_notifies_all_components() {
+    let db = setup_test_db().await;
+    let provider = vec![0x76u8; 32];
+    let user = vec![0x77u8; 32];
+
+    insert_test_offering(&db, 14, &provider, "US", 10.0).await;
+    let offering_id = test_id_to_db_id(14);
+
+    sqlx::query(
+        "UPDATE provider_offerings SET price_per_unit = 0.50, overage_price_per_unit = 1.00, pricing_model = 'usage_overage' WHERE id = $1",
+    )
+    .bind(offering_id)
+    .execute(&db.pool)
+    .await
+    .expect("set initial usage pricing");
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.monthly_price = 12.0;
+    update_params.setup_fee = 5.0;
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert_eq!(notifications.len(), 1, "expected one combined alert");
+    assert_eq!(
+        notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert!(
+        notifications[0]
+            .body
+            .contains("Test Offer pricing changed:"),
+        "expected multi-component prefix: {}",
+        notifications[0].body
+    );
+    assert!(
+        notifications[0].body.contains("monthly_price from USD 10.00 to USD 12.00"),
+        "expected monthly_price in body: {}",
+        notifications[0].body
+    );
+    assert!(
+        notifications[0].body.contains("setup_fee from USD 0.00 to USD 5.00"),
+        "expected setup_fee in body: {}",
+        notifications[0].body
+    );
 }
 
 #[tokio::test]
@@ -3539,7 +3743,7 @@ async fn test_bulk_update_offering_prices_notifies_only_changed_saved_offerings(
     assert!(
         changed_notifications[0]
             .body
-            .contains("Test Offer changed from USD 10.00 to USD 15.00."),
+            .contains("Test Offer: monthly_price from USD 10.00 to USD 15.00."),
         "unexpected changed notification body: {}",
         changed_notifications[0].body
     );


### PR DESCRIPTION
## Summary

Extends the saved-offering price-change notification system (from #191) to detect changes to `setup_fee`, `price_per_unit`, and `overage_price_per_unit` in addition to the existing `monthly_price` monitoring.

## Changes

- **`SavedOfferingPriceChange` struct**: Extended with `old_setup_fee`/`new_setup_fee` (`f64`), `old_price_per_unit`/`new_price_per_unit` (`Option<f64>`), `old_overage_price_per_unit`/`new_overage_price_per_unit` (`Option<f64>`)
- **`notify_saved_offering_price_change`**: Now detects changes to all pricing components and builds a notification body listing which component(s) changed. Single-component: `"Offer: monthly_price from USD 10.00 to USD 12.00."`. Multi-component: `"Offer pricing changed: monthly_price from USD 10.00 to USD 12.00; setup_fee from USD 0.00 to USD 5.00."`
- **`update_offering`**: Captures existing `setup_fee`, `price_per_unit`, `overage_price_per_unit` from DB and passes them into the price-change detection
- **`bulk_update_offering_prices`**: Passes through unchanged secondary fields for consistent notification construction
- **`opt_f64_changed`**: Helper for comparing `Option<f64>` fields (only reports change when both old and new are `Some` and differ)

## Tests

- `test_update_offering_setup_fee_change_notifies_saved_users` — setup_fee change detection
- `test_update_offering_price_per_unit_change_notifies_saved_users` — price_per_unit change detection
- `test_update_offering_overage_price_per_unit_change_notifies_saved_users` — overage_price_per_unit change detection
- `test_update_offering_multiple_price_changes_notifies_all_components` — combined monthly_price + setup_fee change
- Existing tests updated for new notification body format

## Test plan

- [x] All targeted tests pass (20/20 across lib + bin targets)
- [x] Clippy clean (no new warnings)
- [x] Compilation clean
- [ ] CI full test suite

Closes #193