### PR TITLE
fix(#192): read direction from JSON body, fix test ordering, scope error handling

### DIFF
--- a/website/src/lib/components/NotificationBell.svelte
+++ b/website/src/lib/components/NotificationBell.svelte
@@ -43,6 +43,18 @@
 		}
 	}
 
+	function displayBody(body: string): string {
+		try {
+			const parsed = JSON.parse(body);
+			if (parsed && typeof parsed.text === 'string') {
+				return parsed.text.length > 60 ? parsed.text.slice(0, 60) + '…' : parsed.text;
+			}
+		} catch {
+			// Not JSON — use raw string
+		}
+		return body.length > 60 ? body.slice(0, 60) + '…' : body;
+	}
+
 	async function getSignedHeaders(method: string, path: string) {
 		if (!activeIdentity?.identity || !(activeIdentity.identity instanceof Ed25519KeyIdentity)) {
 			throw new Error('No active Ed25519 identity');
@@ -238,7 +250,7 @@
 									<span class="flex-1 min-w-0">
 										<span class="block text-sm text-white font-medium">{notification.title}</span>
 										<span class="block text-xs text-neutral-400 truncate mt-0.5">
-											{notification.body.length > 60 ? notification.body.slice(0, 60) + '…' : notification.body}
+											{displayBody(notification.body)}
 										</span>
 									</span>
 									<span class="flex-shrink-0 text-xs text-neutral-600 mt-0.5">
@@ -267,7 +279,7 @@
 									<span class="flex-1 min-w-0">
 										<span class="block text-sm text-neutral-300">{notification.title}</span>
 										<span class="block text-xs text-neutral-500 truncate mt-0.5">
-											{notification.body.length > 60 ? notification.body.slice(0, 60) + '…' : notification.body}
+											{displayBody(notification.body)}
 										</span>
 									</span>
 									<span class="flex-shrink-0 text-xs text-neutral-600 mt-0.5">

--- a/website/src/routes/dashboard/saved/+page.svelte
+++ b/website/src/routes/dashboard/saved/+page.svelte
@@ -49,13 +49,17 @@
 			offerings = await getSavedOfferings(headers, pubkeyHex);
 			savedIds = new Set(offerings.map((o) => o.id).filter((id): id is number => id !== undefined));
 
-			const notifHeaders = (await signRequest(info.identity, 'GET', `/api/v1/users/${pubkeyHex}/notifications`)).headers;
-			const notifications = await getUserNotifications(notifHeaders, pubkeyHex);
-			const { byOfferingId, unreadNotificationIds } = collectSavedOfferingPriceChanges(notifications);
-			priceChangeMap = byOfferingId;
-			if (unreadNotificationIds.length > 0) {
-				const markHeaders = (await signRequest(info.identity, 'POST', `/api/v1/users/${pubkeyHex}/notifications/mark-read`)).headers;
-				await markNotificationsRead(markHeaders, pubkeyHex, unreadNotificationIds);
+			try {
+				const notifHeaders = (await signRequest(info.identity, 'GET', `/api/v1/users/${pubkeyHex}/notifications`)).headers;
+				const notifications = await getUserNotifications(notifHeaders, pubkeyHex);
+				const { byOfferingId, unreadNotificationIds } = collectSavedOfferingPriceChanges(notifications);
+				priceChangeMap = byOfferingId;
+				if (unreadNotificationIds.length > 0) {
+					const markHeaders = (await signRequest(info.identity, 'POST', `/api/v1/users/${pubkeyHex}/notifications/mark-read`)).headers;
+					await markNotificationsRead(markHeaders, pubkeyHex, unreadNotificationIds);
+				}
+			} catch {
+				// Price indicators are non-critical — silently degrade
 			}
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load saved offerings';


### PR DESCRIPTION
## Summary
- **`+page.svelte`**: wrap price-change notification logic in a separate try/catch so notification failures no longer show misleading "Failed to load saved offerings" error when offerings loaded fine.
- **`NotificationBell.svelte`**: add `displayBody()` helper that gracefully extracts `.text` from JSON bodies (backward compatible with plain text).

## Why
- Single try/catch meant notification fetch failures (network, auth, API errors) showed the wrong error message, blocking the entire saved-offerings page even though offerings loaded successfully.
- `displayBody()` is a defensive improvement that handles both current plain-text bodies and potential future JSON-encoded notification bodies.

## What was dropped from the original PR
The original PR #236 included backend changes (extract `insert_notification`, encode body as JSON) and frontend changes (parse direction from JSON body). These are **no longer needed** because:
- PR #235 already merged `insert_notification` with `price_direction` param
- PR #240 already added the structured `price_direction` column
- Frontend already reads `notification.priceDirection` directly from the API

## Test plan
- [x] `vitest run` — 839 tests pass (0 fail)
- [x] `svelte-check` — 0 errors
- [x] Branch is mergeable against latest main