### PR TITLE
feat: use structured notification price direction

### DIFF
--- a/api/migrations_pg/040_notification_price_direction.sql
+++ b/api/migrations_pg/040_notification_price_direction.sql
@@ -1,1 +1,1 @@
-ALTER TABLE user_notifications ADD COLUMN price_direction TEXT;
+ALTER TABLE user_notifications ADD COLUMN price_direction TEXT CHECK (price_direction IN ('up', 'down'));

--- a/api/migrations_pg/040_notification_price_direction.sql
+++ b/api/migrations_pg/040_notification_price_direction.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_notifications ADD COLUMN price_direction TEXT;

--- a/api/src/database/offerings.rs
+++ b/api/src/database/offerings.rs
@@ -1087,9 +1087,9 @@ impl Database {
             .zip(change.new_overage_price_per_unit)
             .is_some_and(|(o, n)| n < o);
         let direction = if monthly_dropped || setup_dropped || ppu_dropped || opu_dropped {
-            "dropped"
+            "down"
         } else {
-            "changed"
+            "up"
         };
         let title = format!("Saved offering price {}", direction);
 
@@ -1103,13 +1103,14 @@ impl Database {
 
         for user_pubkey in saved_user_pubkeys {
             sqlx::query(
-                "INSERT INTO user_notifications (user_pubkey, type, title, body, contract_id, offering_id, created_at) VALUES ($1, $2, $3, $4, NULL, $5, $6)",
+                "INSERT INTO user_notifications (user_pubkey, type, title, body, contract_id, offering_id, price_direction, created_at) VALUES ($1, $2, $3, $4, NULL, $5, $6, $7)",
             )
             .bind(user_pubkey.as_slice())
             .bind("saved_offering_price_change")
             .bind(&title)
             .bind(&body)
             .bind(offering_id)
+            .bind(direction)
             .bind(created_at)
             .execute(&mut **tx)
             .await?;

--- a/api/src/database/offerings/tests.rs
+++ b/api/src/database/offerings/tests.rs
@@ -3407,7 +3407,8 @@ async fn test_update_offering_price_change_notifies_saved_users() {
             "saved_offering_price_change"
         );
         assert_eq!(notifications[0].offering_id, Some(offering_id));
-        assert_eq!(notifications[0].title, "Saved offering price changed");
+        assert_eq!(notifications[0].title, "Saved offering price up");
+        assert_eq!(notifications[0].price_direction, Some("up".to_string()));
         assert!(
             notifications[0]
                 .body

--- a/api/src/database/offerings/tests.rs
+++ b/api/src/database/offerings/tests.rs
@@ -3420,10 +3420,54 @@ async fn test_update_offering_price_change_notifies_saved_users() {
 }
 
 #[tokio::test]
-async fn test_update_offering_same_price_does_not_notify_saved_users() {
+async fn test_update_offering_price_decrease_sets_direction_down() {
     let db = setup_test_db().await;
     let provider = vec![0x69u8; 32];
     let user = vec![0x6Au8; 32];
+
+    insert_test_offering(&db, 8, &provider, "US", 15.0).await;
+    let offering_id = test_id_to_db_id(8);
+
+    db.save_offering(&user, offering_id)
+        .await
+        .expect("save_offering should succeed");
+
+    let mut update_params = db
+        .get_offering(offering_id)
+        .await
+        .expect("get_offering should succeed")
+        .expect("offering should exist");
+    update_params.monthly_price = 10.0;
+
+    db.update_offering(&provider, offering_id, update_params)
+        .await
+        .expect("update_offering should succeed");
+
+    let notifications = db
+        .get_user_notifications(&user, 10)
+        .await
+        .expect("get_user_notifications should succeed");
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(
+        notifications[0].notification_type,
+        "saved_offering_price_change"
+    );
+    assert_eq!(notifications[0].title, "Saved offering price down");
+    assert_eq!(notifications[0].price_direction, Some("down".to_string()));
+    assert!(
+        notifications[0]
+            .body
+            .contains("Test Offer: monthly_price from USD 15.00 to USD 10.00."),
+        "unexpected notification body: {}",
+        notifications[0].body
+    );
+}
+
+#[tokio::test]
+async fn test_update_offering_same_price_does_not_notify_saved_users() {
+    let db = setup_test_db().await;
+    let provider = vec![0x79u8; 32];
+    let user = vec![0x7Au8; 32];
 
     insert_test_offering(&db, 8, &provider, "US", 10.0).await;
     let offering_id = test_id_to_db_id(8);
@@ -3483,6 +3527,8 @@ async fn test_update_offering_setup_fee_change_notifies_saved_users() {
         notifications[0].notification_type,
         "saved_offering_price_change"
     );
+    assert_eq!(notifications[0].title, "Saved offering price up");
+    assert_eq!(notifications[0].price_direction, Some("up".to_string()));
     assert!(
         notifications[0]
             .body
@@ -3584,6 +3630,7 @@ async fn test_update_offering_overage_price_per_unit_change_notifies_saved_users
         notifications[0].notification_type,
         "saved_offering_price_change"
     );
+    assert_eq!(notifications[0].price_direction, Some("up".to_string()));
     assert!(
         notifications[0]
             .body
@@ -3635,6 +3682,7 @@ async fn test_update_offering_multiple_price_changes_notifies_all_components() {
         notifications[0].notification_type,
         "saved_offering_price_change"
     );
+    assert_eq!(notifications[0].price_direction, Some("up".to_string()));
     assert!(
         notifications[0]
             .body

--- a/api/src/database/test_helpers.rs
+++ b/api/src/database/test_helpers.rs
@@ -347,6 +347,7 @@ fn migration_hash() -> String {
     include_str!("../../migrations_pg/037_totp_2fa.sql").hash(&mut hasher);
     include_str!("../../migrations_pg/038_provider_offering_sli_reports.sql").hash(&mut hasher);
     include_str!("../../migrations_pg/039_notification_offering_id.sql").hash(&mut hasher);
+    include_str!("../../migrations_pg/040_notification_price_direction.sql").hash(&mut hasher);
     format!("{:x}", hasher.finish())
 }
 
@@ -672,6 +673,10 @@ async fn ensure_template_db(base_url: &str) -> String {
                 (
                     "039_notification_offering_id.sql",
                     include_str!("../../migrations_pg/039_notification_offering_id.sql"),
+                ),
+                (
+                    "040_notification_price_direction.sql",
+                    include_str!("../../migrations_pg/040_notification_price_direction.sql"),
                 ),
             ];
 

--- a/api/src/database/user_notifications.rs
+++ b/api/src/database/user_notifications.rs
@@ -10,6 +10,7 @@ pub struct UserNotification {
     pub body: String,
     pub contract_id: Option<String>,
     pub offering_id: Option<i64>,
+    pub price_direction: Option<String>,
     pub read_at: Option<i64>,
     pub created_at: i64,
 }
@@ -24,6 +25,7 @@ impl Database {
         body: &str,
         contract_id: Option<&str>,
         offering_id: Option<i64>,
+        price_direction: Option<&str>,
     ) -> Result<i64> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -31,8 +33,8 @@ impl Database {
             .as_secs() as i64;
 
         let id = sqlx::query_scalar!(
-            r#"INSERT INTO user_notifications (user_pubkey, type, title, body, contract_id, offering_id, created_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)
+            r#"INSERT INTO user_notifications (user_pubkey, type, title, body, contract_id, offering_id, price_direction, created_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                RETURNING id"#,
             user_pubkey,
             notification_type,
@@ -40,6 +42,7 @@ impl Database {
             body,
             contract_id,
             offering_id,
+            price_direction,
             now,
         )
         .fetch_one(&self.pool)
@@ -55,7 +58,7 @@ impl Database {
         limit: i64,
     ) -> Result<Vec<UserNotification>> {
         let rows = sqlx::query!(
-            r#"SELECT id, type, title, body, contract_id, offering_id, read_at, created_at
+            r#"SELECT id, type, title, body, contract_id, offering_id, price_direction, read_at, created_at
                FROM user_notifications
                WHERE user_pubkey = $1
                ORDER BY created_at DESC, id DESC
@@ -75,6 +78,7 @@ impl Database {
                 body: r.body,
                 contract_id: r.contract_id,
                 offering_id: r.offering_id,
+                price_direction: r.price_direction,
                 read_at: r.read_at,
                 created_at: r.created_at,
             })
@@ -154,6 +158,7 @@ mod tests {
                 "Your rental request was accepted.",
                 Some("abc123"),
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -166,6 +171,7 @@ mod tests {
         assert_eq!(notifications[0].notification_type, "contract_status");
         assert_eq!(notifications[0].title, "Contract Accepted");
         assert_eq!(notifications[0].contract_id.as_deref(), Some("abc123"));
+        assert!(notifications[0].price_direction.is_none());
         assert!(notifications[0].read_at.is_none());
     }
 
@@ -186,10 +192,10 @@ mod tests {
         // No notifications yet
         assert_eq!(db.get_unread_count(&pubkey).await.unwrap(), 0);
 
-        db.insert_user_notification(&pubkey, "contract_provisioned", "VM Ready", "Your VM is provisioned.", None, None)
+        db.insert_user_notification(&pubkey, "contract_provisioned", "VM Ready", "Your VM is provisioned.", None, None, None)
         .await
         .unwrap();
-        db.insert_user_notification(&pubkey, "auto_renewed", "Auto-renewed", "Contract was renewed.", None, None)
+        db.insert_user_notification(&pubkey, "auto_renewed", "Auto-renewed", "Contract was renewed.", None, None, None)
         .await
         .unwrap();
 
@@ -209,6 +215,7 @@ mod tests {
                 "Contract was cancelled.",
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -218,6 +225,7 @@ mod tests {
                 "contract_status",
                 "Rejected",
                 "Contract was rejected.",
+                None,
                 None,
                 None,
             )
@@ -249,6 +257,7 @@ mod tests {
             "A tenant rented your VM.",
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -257,6 +266,7 @@ mod tests {
             "password_reset_complete",
             "Password Reset",
             "Password was reset.",
+            None,
             None,
             None,
         )
@@ -277,7 +287,7 @@ mod tests {
         let user_b = vec![0x06u8; 32];
 
         let id = db
-            .insert_user_notification(&user_a, "contract_status", "Title", "Body", None, None)
+            .insert_user_notification(&user_a, "contract_status", "Title", "Body", None, None, None)
             .await
             .unwrap();
 
@@ -301,6 +311,7 @@ mod tests {
                 "body",
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -316,11 +327,11 @@ mod tests {
         let pubkey = vec![0x08u8; 32];
 
         let id1 = db
-            .insert_user_notification(&pubkey, "contract_status", "First", "body", None, None)
+            .insert_user_notification(&pubkey, "contract_status", "First", "body", None, None, None)
             .await
             .unwrap();
         let id2 = db
-            .insert_user_notification(&pubkey, "contract_status", "Second", "body", None, None)
+            .insert_user_notification(&pubkey, "contract_status", "Second", "body", None, None, None)
             .await
             .unwrap();
 
@@ -343,6 +354,7 @@ mod tests {
                 "Test Offer: monthly_price from USD 10.00 to USD 12.50.",
                 None,
                 Some(42),
+                Some("up"),
             )
             .await
             .unwrap();
@@ -350,6 +362,7 @@ mod tests {
         let notifications = db.get_user_notifications(&pubkey, 50).await.unwrap();
         assert_eq!(notifications.len(), 1);
         assert_eq!(notifications[0].offering_id, Some(42));
+        assert_eq!(notifications[0].price_direction.as_deref(), Some("up"));
 
         let id2 = db
             .insert_user_notification(
@@ -358,6 +371,7 @@ mod tests {
                 "Accepted",
                 "Contract accepted.",
                 Some("c1"),
+                None,
                 None,
             )
             .await

--- a/api/src/database/user_notifications.rs
+++ b/api/src/database/user_notifications.rs
@@ -17,6 +17,7 @@ pub struct UserNotification {
 
 impl Database {
     /// Insert a new notification for the given user. Returns the new notification ID.
+    #[allow(clippy::too_many_arguments)]
     pub async fn insert_user_notification(
         &self,
         user_pubkey: &[u8],
@@ -383,5 +384,26 @@ mod tests {
         assert_eq!(with_offering.offering_id, Some(42));
         let without_offering = notifications.iter().find(|n| n.id == id2).unwrap();
         assert_eq!(without_offering.offering_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_notification_rejects_invalid_price_direction() {
+        let db = setup_test_db().await;
+        let pubkey = vec![0x0Au8; 32];
+
+        let err = db
+            .insert_user_notification(
+                &pubkey,
+                "saved_offering_price_change",
+                "Saved offering price changed",
+                "Test Offer: monthly_price from USD 10.00 to USD 12.50.",
+                None,
+                Some(42),
+                Some("sideways"),
+            )
+            .await
+            .expect_err("invalid price direction should fail");
+
+        assert!(err.to_string().contains("user_notifications_price_direction_check"));
     }
 }

--- a/api/src/openapi/common.rs
+++ b/api/src/openapi/common.rs
@@ -1024,6 +1024,26 @@ mod tests {
     }
 
     #[test]
+    fn test_user_notification_response_serializes_price_direction_in_camel_case() {
+        let resp = UserNotificationResponse {
+            id: 7,
+            notification_type: "saved_offering_price_change".to_string(),
+            title: "Saved offering price up".to_string(),
+            body: "Offer A: monthly_price from USD 10.00 to USD 12.50.".to_string(),
+            contract_id: None,
+            offering_id: Some(42),
+            price_direction: Some("down".to_string()),
+            read_at: None,
+            created_at: 123,
+        };
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["offeringId"], 42);
+        assert_eq!(json["priceDirection"], "down");
+        assert!(json.get("price_direction").is_none());
+    }
+
+    #[test]
     fn test_reconcile_request_deserialization() {
         let json = r#"{"runningInstances":[{"externalId":"vm-100","contractId":"c-123"}]}"#;
         let req: ReconcileRequest = serde_json::from_str(json).unwrap();

--- a/api/src/openapi/common.rs
+++ b/api/src/openapi/common.rs
@@ -732,6 +732,9 @@ pub struct UserNotificationResponse {
     pub offering_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[oai(skip_serializing_if_is_none)]
+    pub price_direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[oai(skip_serializing_if_is_none)]
     pub read_at: Option<i64>,
     pub created_at: i64,
 }

--- a/api/src/openapi/contracts.rs
+++ b/api/src/openapi/contracts.rs
@@ -72,7 +72,7 @@ pub async fn check_spending_alert_and_notify(db: &Database, requester_pubkey: &[
     };
 
     if let Err(e) = db
-        .insert_user_notification(requester_pubkey, "spending_alert", &title, &body, None, None)
+        .insert_user_notification(requester_pubkey, "spending_alert", &title, &body, None, None, None)
         .await
     {
         tracing::warn!(

--- a/api/src/openapi/offerings.rs
+++ b/api/src/openapi/offerings.rs
@@ -639,6 +639,7 @@ impl OfferingsApi {
                 &body_text,
                 None,
                 None,
+                None,
             )
             .await
         {

--- a/api/src/openapi/users.rs
+++ b/api/src/openapi/users.rs
@@ -393,6 +393,7 @@ impl UsersApi {
                         body: n.body,
                         contract_id: n.contract_id,
                         offering_id: n.offering_id,
+                        price_direction: n.price_direction,
                         read_at: n.read_at,
                         created_at: n.created_at,
                     })

--- a/api/src/receipts.rs
+++ b/api/src/receipts.rs
@@ -304,6 +304,7 @@ pub async fn send_contract_accepted_notification(db: &Database, contract_id: &[u
                 ),
                 Some(&contract_hex),
                 None,
+                None,
             )
             .await
         {
@@ -425,6 +426,7 @@ pub async fn send_contract_rejected_notification(
                     reason_text
                 ),
                 Some(&contract_hex),
+                None,
                 None,
             )
             .await

--- a/api/src/rental_notifications.rs
+++ b/api/src/rental_notifications.rs
@@ -101,6 +101,7 @@ pub async fn notify_provider_new_rental(
             ),
             Some(&contract.contract_id),
             None,
+            None,
         )
         .await
     {
@@ -333,6 +334,7 @@ pub async fn notify_user_provisioned(
                 &contract.contract_id[..16]
             ),
             Some(&contract.contract_id),
+            None,
             None,
         )
         .await
@@ -795,6 +797,7 @@ pub async fn notify_tenant_password_reset_complete(
                 &contract.contract_id[..16]
             ),
             Some(&contract.contract_id),
+            None,
             None,
         )
         .await

--- a/website/src/lib/services/api.ts
+++ b/website/src/lib/services/api.ts
@@ -3740,10 +3740,12 @@ export interface UserNotification {
 	body: string;
 	contractId?: string;
 	offeringId?: number;
-	priceDirection?: string;
+	priceDirection?: UserNotificationPriceDirection;
 	readAt?: number;
 	createdAt: number;
 }
+
+export type UserNotificationPriceDirection = 'up' | 'down';
 
 export async function getUserNotifications(
 	headers: SignedRequestHeaders,

--- a/website/src/lib/services/api.ts
+++ b/website/src/lib/services/api.ts
@@ -3740,6 +3740,7 @@ export interface UserNotification {
 	body: string;
 	contractId?: string;
 	offeringId?: number;
+	priceDirection?: string;
 	readAt?: number;
 	createdAt: number;
 }

--- a/website/src/lib/utils/saved-offering-price-change.test.ts
+++ b/website/src/lib/utils/saved-offering-price-change.test.ts
@@ -8,17 +8,19 @@ describe('collectSavedOfferingPriceChanges', () => {
 			{
 				id: 1,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price dropped',
+				title: 'Saved offering price down',
 				body: 'Offer A: monthly_price from USD 12.00 to USD 10.00.',
 				offeringId: 42,
+				priceDirection: 'down',
 				createdAt: 1
 			},
 			{
 				id: 2,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price changed',
+				title: 'Saved offering price up',
 				body: 'Offer B: monthly_price from USD 10.00 to USD 12.00.',
 				offeringId: 99,
+				priceDirection: 'up',
 				createdAt: 2
 			}
 		]);
@@ -35,9 +37,10 @@ describe('collectSavedOfferingPriceChanges', () => {
 			{
 				id: 1,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price dropped',
+				title: 'Saved offering price down',
 				body: 'Offer A: monthly_price from USD 12.00 to USD 10.00.',
 				offeringId: 42,
+				priceDirection: 'down',
 				createdAt: 1,
 				readAt: 5
 			},
@@ -51,29 +54,48 @@ describe('collectSavedOfferingPriceChanges', () => {
 			{
 				id: 3,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price dropped',
+				title: 'Saved offering price down',
 				body: 'Offer B: monthly_price from USD 12.00 to USD 10.00.',
+				priceDirection: 'down',
 				createdAt: 3
 			},
 			{
 				id: 4,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price dropped',
+				title: 'Saved offering price down',
 				body: 'Offer C: monthly_price from USD 12.00 to USD 10.00.',
 				offeringId: 7,
+				priceDirection: 'down',
 				createdAt: 4
 			},
 			{
 				id: 5,
 				notificationType: 'saved_offering_price_change',
-				title: 'Saved offering price changed',
+				title: 'Saved offering price up',
 				body: 'Offer C: monthly_price from USD 10.00 to USD 12.00.',
 				offeringId: 7,
+				priceDirection: 'up',
 				createdAt: 5
 			}
 		]);
 
 		expect(result.unreadNotificationIds).toEqual([4, 5]);
 		expect(Array.from(result.byOfferingId.entries())).toEqual([[7, 'down']]);
+	});
+
+	it('prefers structured direction over title text', () => {
+		const result = collectSavedOfferingPriceChanges([
+			{
+				id: 1,
+				notificationType: 'saved_offering_price_change',
+				title: 'Saved offering price up',
+				body: 'Offer D: monthly_price from USD 12.00 to USD 10.00.',
+				offeringId: 55,
+				priceDirection: 'down',
+				createdAt: 1
+			}
+		]);
+
+		expect(Array.from(result.byOfferingId.entries())).toEqual([[55, 'down']]);
 	});
 });

--- a/website/src/lib/utils/saved-offering-price-change.ts
+++ b/website/src/lib/utils/saved-offering-price-change.ts
@@ -1,6 +1,6 @@
-import type { UserNotification } from '$lib/services/api';
+import type { UserNotification, UserNotificationPriceDirection } from '$lib/services/api';
 
-export type SavedOfferingPriceChangeDirection = 'up' | 'down';
+export type SavedOfferingPriceChangeDirection = UserNotificationPriceDirection;
 
 export interface SavedOfferingPriceChangeSummary {
 	byOfferingId: Map<number, SavedOfferingPriceChangeDirection>;

--- a/website/src/lib/utils/saved-offering-price-change.ts
+++ b/website/src/lib/utils/saved-offering-price-change.ts
@@ -29,7 +29,8 @@ export function collectSavedOfferingPriceChanges(
 
 		byOfferingId.set(
 			notification.offeringId,
-			notification.title.includes('dropped') ? 'down' : 'up'
+			// The API now carries direction explicitly; titles are presentation-only.
+			notification.priceDirection === 'down' ? 'down' : 'up'
 		);
 	}
 


### PR DESCRIPTION
## Summary
- persist `price_direction` on saved-offering price change notifications and constrain it to `up`/`down` in PostgreSQL
- expose `priceDirection` through the user notifications API contract and tighten the website notification type to the same union
- add backend and frontend coverage so the saved-offerings UI uses the payload field instead of inferring direction from the title text

## Test Plan
- `TEST_DATABASE_URL="postgres://test:test@postgres:5432/test" cargo test -p api test_notification_rejects_invalid_price_direction`
- `cargo test -p api test_user_notification_response_serializes_price_direction_in_camel_case`
- `npm test -- saved-offering-price-change.test.ts -t "prefers structured direction over title text"`
- `npm run check`
- `TEST_DATABASE_URL="postgres://test:test@postgres:5432/test" cargo clippy -p api --tests -- -D warnings`
- `TEST_DATABASE_URL="postgres://test:test@postgres:5432/test" cargo test` (fails in `ic-canister` build because local `dfxvm default <version>` is not configured; matches known workspace issue)
- `npm test`
- manual backend validation against a live local `api-server`: created a signed test account, inserted a saved-offering notification in PostgreSQL, and fetched `/api/v1/users/:pubkey/notifications`; the live response returned `priceDirection: "down"` even with title `"Saved offering price up"`
