### PR TITLE
feat(#195): emit SSH key rotation events into SSE stream

### DIFF
--- a/api/src/database/contracts/extensions.rs
+++ b/api/src/database/contracts/extensions.rs
@@ -253,4 +253,32 @@ impl Database {
 
         Ok(events)
     }
+
+    /// Get recent SSH key rotation events across all contracts for a user,
+    /// created after the given timestamp (nanoseconds since epoch).
+    /// Returns events ordered by created_at ASC.
+    pub async fn get_ssh_key_rotation_events_for_user(
+        &self,
+        requester_pubkey: &[u8],
+        after_ns: i64,
+    ) -> Result<Vec<ContractEvent>> {
+        let events = sqlx::query_as!(
+            ContractEvent,
+            r#"SELECT ce.id as "id!", lower(encode(ce.contract_id, 'hex')) as "contract_id!: String",
+                ce.event_type as "event_type!", ce.old_status, ce.new_status,
+                ce.actor as "actor!", ce.details, ce.created_at as "created_at!"
+                FROM contract_events ce
+                JOIN contract_sign_requests csr ON csr.contract_id = ce.contract_id
+                WHERE csr.requester_pubkey = $1
+                  AND ce.event_type IN ('ssh_key_rotation', 'ssh_key_rotation_complete')
+                  AND ce.created_at > $2
+                ORDER BY ce.created_at ASC"#,
+            requester_pubkey,
+            after_ns
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(events)
+    }
 }

--- a/api/src/database/contracts/tests.rs
+++ b/api/src/database/contracts/tests.rs
@@ -825,6 +825,103 @@ async fn test_request_ssh_key_rotation_stages_pending_key_until_completion() {
 }
 
 #[tokio::test]
+async fn test_get_ssh_key_rotation_events_for_user_returns_rotation_events() {
+    let db = setup_test_db().await;
+    let contract_id = vec![80u8; 32];
+    let requester_pk = vec![3u8; 32];
+    let provider_pk = vec![4u8; 32];
+    let other_pk = vec![5u8; 32];
+
+    insert_contract_request(
+        &db,
+        &contract_id,
+        &requester_pk,
+        &provider_pk,
+        "off-sse-rot",
+        0,
+        "active",
+    )
+    .await;
+
+    db.add_provisioning_details(&contract_id, "ip:1.2.3.4\nuser:root")
+        .await
+        .unwrap();
+
+    let other_contract_id = vec![81u8; 32];
+    insert_contract_request(
+        &db,
+        &other_contract_id,
+        &other_pk,
+        &provider_pk,
+        "off-sse-rot2",
+        0,
+        "active",
+    )
+    .await;
+
+    db.add_provisioning_details(&other_contract_id, "ip:5.6.7.8\nuser:root")
+        .await
+        .unwrap();
+
+    let before_rotation = crate::now_ns().unwrap();
+    db.request_ssh_key_rotation(&contract_id, "ssh-ed25519 NEWKEY1")
+        .await
+        .unwrap();
+    db.request_ssh_key_rotation(&other_contract_id, "ssh-ed25519 NEWKEY2")
+        .await
+        .unwrap();
+
+    let events = db
+        .get_ssh_key_rotation_events_for_user(&requester_pk, 0)
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].contract_id, hex::encode(&contract_id));
+    assert_eq!(events[0].event_type, "ssh_key_rotation");
+    assert_eq!(events[0].actor, "tenant");
+    assert!(events[0].created_at >= before_rotation);
+
+    db.complete_ssh_key_rotation(&contract_id)
+        .await
+        .unwrap();
+    db.insert_contract_event(
+        &contract_id,
+        "ssh_key_rotation_complete",
+        None,
+        None,
+        "provider",
+        Some("SSH key rotated to ssh-ed25519 NEWKEY... by agent"),
+    )
+    .await
+    .unwrap();
+
+    let all_events = db
+        .get_ssh_key_rotation_events_for_user(&requester_pk, 0)
+        .await
+        .unwrap();
+    assert_eq!(all_events.len(), 2);
+    assert_eq!(all_events[0].event_type, "ssh_key_rotation");
+    assert_eq!(all_events[1].event_type, "ssh_key_rotation_complete");
+
+    let after_all = all_events[1].created_at;
+    let filtered = db
+        .get_ssh_key_rotation_events_for_user(&requester_pk, after_all)
+        .await
+        .unwrap();
+    assert!(
+        filtered.is_empty(),
+        "after_ns filter should exclude events at or before the cutoff"
+    );
+
+    let other_events = db
+        .get_ssh_key_rotation_events_for_user(&other_pk, 0)
+        .await
+        .unwrap();
+    assert_eq!(other_events.len(), 1);
+    assert_eq!(other_events[0].contract_id, hex::encode(&other_contract_id));
+}
+
+#[tokio::test]
 async fn test_cancel_contract_success_requested() {
     let db = setup_test_db().await;
     let contract_id = vec![10u8; 32];

--- a/api/src/openapi/providers.rs
+++ b/api/src/openapi/providers.rs
@@ -168,25 +168,30 @@ pub async fn contract_status_events(
         ));
     }
 
-    // Snapshot: contract_id -> (status, updated_at_ns)
     type Snapshot = std::collections::HashMap<String, (String, Option<i64>)>;
 
+    struct SseState {
+        db: Arc<Database>,
+        pk: Vec<u8>,
+        prev_snapshot: Option<Snapshot>,
+        poll_count: u32,
+        last_rotation_event_ns: i64,
+    }
+
     let db_clone: Arc<Database> = Arc::clone(&db);
-    // Close after 5 minutes: 60 polls × 5 seconds
+    let initial = SseState {
+        db: db_clone,
+        pk: pubkey_bytes,
+        prev_snapshot: None,
+        poll_count: 0,
+        last_rotation_event_ns: 0,
+    };
     let stream =
-        futures::stream::unfold(
-            (db_clone, pubkey_bytes, None::<Snapshot>, 0u32, 0i64),
-            |(db, pk, prev_snapshot, poll_count, last_event_ns): (
-                Arc<Database>,
-                Vec<u8>,
-                Option<Snapshot>,
-                u32,
-                i64,
-            )| async move {
-                if poll_count >= 60 {
-                    return None;
-                }
-                let contracts = match db.get_user_contracts(&pk).await {
+        futures::stream::unfold(initial, |state: SseState| async move {
+            if state.poll_count >= 60 {
+                return None;
+            }
+            let contracts = match state.db.get_user_contracts(&state.pk).await {
                     Ok(c) => c,
                     Err(e) => {
                         tracing::error!("SSE contract-status-events DB error: {:#}", e);
@@ -204,9 +209,8 @@ pub async fn contract_status_events(
                     })
                     .collect();
 
-                let mut events: Vec<Event> = match &prev_snapshot {
+                let mut events: Vec<Event> = match &state.prev_snapshot {
                     None => {
-                        // First poll: emit all contracts
                         contracts
                             .iter()
                             .map(|c| {
@@ -220,7 +224,6 @@ pub async fn contract_status_events(
                             .collect()
                     }
                     Some(prev) => {
-                        // Subsequent polls: emit only changed contracts
                         contracts
                             .iter()
                             .filter(|c| {
@@ -228,7 +231,7 @@ pub async fn contract_status_events(
                                     .map(|(ps, pt)| {
                                         ps != &c.status || pt != &c.status_updated_at_ns
                                     })
-                                    .unwrap_or(true) // new contract
+                                    .unwrap_or(true)
                             })
                             .map(|c| {
                                 let data = serde_json::json!({
@@ -242,9 +245,11 @@ pub async fn contract_status_events(
                     }
                 };
 
-                let mut new_last_event_ns = last_event_ns;
-                if let Ok(rotation_events) =
-                    db.get_ssh_key_rotation_events_for_user(&pk, last_event_ns).await
+                let mut next_rotation_ns = state.last_rotation_event_ns;
+                if let Ok(rotation_events) = state
+                    .db
+                    .get_ssh_key_rotation_events_for_user(&state.pk, state.last_rotation_event_ns)
+                    .await
                 {
                     for ev in &rotation_events {
                         let data = serde_json::json!({
@@ -254,14 +259,23 @@ pub async fn contract_status_events(
                             "details": ev.details,
                         });
                         events.push(Event::message(data.to_string()).event_type(&ev.event_type));
-                        if ev.created_at > new_last_event_ns {
-                            new_last_event_ns = ev.created_at;
+                        if ev.created_at > next_rotation_ns {
+                            next_rotation_ns = ev.created_at;
                         }
                     }
                 }
 
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                Some((events, (db, pk, Some(current), poll_count + 1, new_last_event_ns)))
+                Some((
+                    events,
+                    SseState {
+                        db: state.db,
+                        pk: state.pk,
+                        prev_snapshot: Some(current),
+                        poll_count: state.poll_count + 1,
+                        last_rotation_event_ns: next_rotation_ns,
+                    },
+                ))
             },
         )
         .flat_map(|events: Vec<Event>| futures::stream::iter(events));

--- a/api/src/openapi/providers.rs
+++ b/api/src/openapi/providers.rs
@@ -136,9 +136,15 @@ pub async fn password_reset_events(
 /// when any contract status or updated_at_ns changes. Keep-alive sent every 30 seconds.
 /// Closes after 5 minutes (client reconnects).
 ///
-/// Event format:
+/// Event types emitted:
 ///   event: contract-status
 ///   data: {"contract_id":"<id>","status":"<status>","updated_at_ns":<ns>}
+///
+///   event: ssh_key_rotation
+///   data: {"contract_id":"<id>","created_at":<ns>,"actor":"tenant","details":null}
+///
+///   event: ssh_key_rotation_complete
+///   data: {"contract_id":"<id>","created_at":<ns>,"actor":"provider","details":"<msg>"}
 #[poem::handler]
 pub async fn contract_status_events(
     req: &poem::Request,
@@ -169,12 +175,13 @@ pub async fn contract_status_events(
     // Close after 5 minutes: 60 polls × 5 seconds
     let stream =
         futures::stream::unfold(
-            (db_clone, pubkey_bytes, None::<Snapshot>, 0u32),
-            |(db, pk, prev_snapshot, poll_count): (
+            (db_clone, pubkey_bytes, None::<Snapshot>, 0u32, 0i64),
+            |(db, pk, prev_snapshot, poll_count, last_event_ns): (
                 Arc<Database>,
                 Vec<u8>,
                 Option<Snapshot>,
                 u32,
+                i64,
             )| async move {
                 if poll_count >= 60 {
                     return None;
@@ -197,7 +204,7 @@ pub async fn contract_status_events(
                     })
                     .collect();
 
-                let events: Vec<Event> = match &prev_snapshot {
+                let mut events: Vec<Event> = match &prev_snapshot {
                     None => {
                         // First poll: emit all contracts
                         contracts
@@ -235,8 +242,26 @@ pub async fn contract_status_events(
                     }
                 };
 
+                let mut new_last_event_ns = last_event_ns;
+                if let Ok(rotation_events) =
+                    db.get_ssh_key_rotation_events_for_user(&pk, last_event_ns).await
+                {
+                    for ev in &rotation_events {
+                        let data = serde_json::json!({
+                            "contract_id": ev.contract_id,
+                            "created_at": ev.created_at,
+                            "actor": ev.actor,
+                            "details": ev.details,
+                        });
+                        events.push(Event::message(data.to_string()).event_type(&ev.event_type));
+                        if ev.created_at > new_last_event_ns {
+                            new_last_event_ns = ev.created_at;
+                        }
+                    }
+                }
+
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                Some((events, (db, pk, Some(current), poll_count + 1)))
+                Some((events, (db, pk, Some(current), poll_count + 1, new_last_event_ns)))
             },
         )
         .flat_map(|events: Vec<Event>| futures::stream::iter(events));
@@ -6125,6 +6150,60 @@ mod tests {
             resp.content_type(),
             Some("text/event-stream"),
             "Contract SSE response must have text/event-stream content type"
+        );
+    }
+
+    #[test]
+    fn test_ssh_key_rotation_sse_event_format_rotation_requested() {
+        let contract_id = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let data = serde_json::json!({
+            "contract_id": contract_id,
+            "created_at": 1_700_000_000_000_000_000_i64,
+            "actor": "tenant",
+            "details": serde_json::Value::Null,
+        });
+        let json_str = data.to_string();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["contract_id"], contract_id);
+        assert_eq!(parsed["created_at"], 1_700_000_000_000_000_000_i64);
+        assert_eq!(parsed["actor"], "tenant");
+        assert!(parsed["details"].is_null());
+    }
+
+    #[test]
+    fn test_ssh_key_rotation_sse_event_format_rotation_complete() {
+        let contract_id = "deadbeef12345678";
+        let data = serde_json::json!({
+            "contract_id": contract_id,
+            "created_at": 1_700_000_001_000_000_000_i64,
+            "actor": "provider",
+            "details": "SSH key rotated to ssh-ed25519 AAA... by agent",
+        });
+        let json_str = data.to_string();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["contract_id"], contract_id);
+        assert_eq!(parsed["actor"], "provider");
+        assert_eq!(parsed["details"], "SSH key rotated to ssh-ed25519 AAA... by agent");
+    }
+
+    #[tokio::test]
+    async fn test_ssh_key_rotation_sse_event_types() {
+        use futures::stream;
+        use poem::web::sse::{Event, SSE};
+        use poem::IntoResponse;
+
+        let events: Vec<Event> = vec![
+            Event::message(r#"{"contract_id":"abc","created_at":123,"actor":"tenant","details":null}"#)
+                .event_type("ssh_key_rotation"),
+            Event::message(r#"{"contract_id":"abc","created_at":456,"actor":"provider","details":"rotated"}"#)
+                .event_type("ssh_key_rotation_complete"),
+        ];
+        let sse = SSE::new(stream::iter(events));
+        let resp = sse.into_response();
+        assert_eq!(
+            resp.content_type(),
+            Some("text/event-stream"),
+            "SSH key rotation SSE events must use text/event-stream"
         );
     }
 

--- a/website/src/lib/utils/contract-sse.test.ts
+++ b/website/src/lib/utils/contract-sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildContractEventsUrl, parseContractEvent, buildPasswordResetEventsUrl, parsePasswordResetEvent } from './contract-sse';
+import { buildContractEventsUrl, parseContractEvent, buildPasswordResetEventsUrl, parsePasswordResetEvent, parseSshKeyRotationEvent } from './contract-sse';
 import type { SignedRequestHeaders } from '$lib/types/generated/SignedRequestHeaders';
 
 describe('buildContractEventsUrl', () => {
@@ -181,5 +181,72 @@ describe('parsePasswordResetEvent', () => {
 
 	it('throws on non-object payload', () => {
 		expect(() => parsePasswordResetEvent('"just a string"')).toThrow('Invalid password reset event payload');
+	});
+});
+
+describe('parseSshKeyRotationEvent', () => {
+	it('parses valid ssh_key_rotation event', () => {
+		const data = JSON.stringify({
+			contract_id: 'abc123',
+			created_at: 1700000000000000000,
+			actor: 'tenant',
+			details: null
+		});
+		const event = parseSshKeyRotationEvent(data);
+		expect(event.contract_id).toBe('abc123');
+		expect(event.created_at).toBe(1700000000000000000);
+		expect(event.actor).toBe('tenant');
+		expect(event.details).toBeNull();
+	});
+
+	it('parses valid ssh_key_rotation_complete event with details', () => {
+		const data = JSON.stringify({
+			contract_id: 'def456',
+			created_at: 1700000001000000000,
+			actor: 'provider',
+			details: 'SSH key rotated to ssh-ed25519 AAA... by agent'
+		});
+		const event = parseSshKeyRotationEvent(data);
+		expect(event.contract_id).toBe('def456');
+		expect(event.created_at).toBe(1700000001000000000);
+		expect(event.actor).toBe('provider');
+		expect(event.details).toBe('SSH key rotated to ssh-ed25519 AAA... by agent');
+	});
+
+	it('defaults created_at to 0 when missing', () => {
+		const data = JSON.stringify({
+			contract_id: 'abc',
+			actor: 'tenant'
+		});
+		const event = parseSshKeyRotationEvent(data);
+		expect(event.created_at).toBe(0);
+	});
+
+	it('defaults details to null when not a string', () => {
+		const data = JSON.stringify({
+			contract_id: 'abc',
+			actor: 'tenant',
+			details: 42
+		});
+		const event = parseSshKeyRotationEvent(data);
+		expect(event.details).toBeNull();
+	});
+
+	it('throws on malformed JSON', () => {
+		expect(() => parseSshKeyRotationEvent('not json')).toThrow();
+	});
+
+	it('throws when contract_id is missing', () => {
+		const data = JSON.stringify({ actor: 'tenant', created_at: 0 });
+		expect(() => parseSshKeyRotationEvent(data)).toThrow('Invalid SSH key rotation event payload');
+	});
+
+	it('throws when actor is missing', () => {
+		const data = JSON.stringify({ contract_id: 'abc', created_at: 0 });
+		expect(() => parseSshKeyRotationEvent(data)).toThrow('Invalid SSH key rotation event payload');
+	});
+
+	it('throws on non-object payload', () => {
+		expect(() => parseSshKeyRotationEvent('"just a string"')).toThrow('Invalid SSH key rotation event payload');
 	});
 });

--- a/website/src/lib/utils/contract-sse.ts
+++ b/website/src/lib/utils/contract-sse.ts
@@ -11,6 +11,13 @@ export interface PasswordResetCountEvent {
 	contract_ids: string[];
 }
 
+export interface SshKeyRotationEvent {
+	contract_id: string;
+	created_at: number;
+	actor: string;
+	details: string | null;
+}
+
 export function buildContractEventsUrl(pubkey: string, apiUrl: string, headers?: SignedRequestHeaders): string {
 	const baseUrl = `${apiUrl}/api/v1/users/${pubkey}/contract-events`;
 	if (!headers) {
@@ -75,5 +82,24 @@ export function parsePasswordResetEvent(data: string): PasswordResetCountEvent {
 	return {
 		count: obj.count as number,
 		contract_ids: obj.contract_ids as string[]
+	};
+}
+
+export function parseSshKeyRotationEvent(data: string): SshKeyRotationEvent {
+	const parsed = JSON.parse(data) as unknown;
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		typeof (parsed as Record<string, unknown>).contract_id !== 'string' ||
+		typeof (parsed as Record<string, unknown>).actor !== 'string'
+	) {
+		throw new Error(`Invalid SSH key rotation event payload: ${data}`);
+	}
+	const obj = parsed as Record<string, unknown>;
+	return {
+		contract_id: obj.contract_id as string,
+		created_at: typeof obj.created_at === 'number' ? (obj.created_at as number) : 0,
+		actor: obj.actor as string,
+		details: typeof obj.details === 'string' ? (obj.details as string) : null
 	};
 }

--- a/website/src/routes/dashboard/rentals/+page.svelte
+++ b/website/src/routes/dashboard/rentals/+page.svelte
@@ -27,7 +27,7 @@
 	import { authStore } from "$lib/stores/auth";
 	import { signRequest } from "$lib/services/auth-api";
 	import { UserApiClient } from "$lib/services/user-api";
-	import { buildContractEventsUrl, parseContractEvent } from "$lib/utils/contract-sse";
+	import { buildContractEventsUrl, parseContractEvent, parseSshKeyRotationEvent } from "$lib/utils/contract-sse";
 	import { get } from "svelte/store";
 	import type { Ed25519KeyIdentity } from "@dfinity/identity";
 
@@ -178,6 +178,30 @@
 				);
 			} catch (e) {
 				console.error('[Rentals] Failed to parse contract SSE event:', e);
+			}
+		});
+		eventSource.addEventListener('ssh_key_rotation', (ev) => {
+			try {
+				const rotation = parseSshKeyRotationEvent(ev.data);
+				contracts = contracts.map((c) =>
+					c.contract_id === rotation.contract_id
+						? { ...c, ssh_key_rotation_requested_at_ns: rotation.created_at }
+						: c
+				);
+			} catch (e) {
+				console.error('[Rentals] Failed to parse ssh_key_rotation SSE event:', e);
+			}
+		});
+		eventSource.addEventListener('ssh_key_rotation_complete', (ev) => {
+			try {
+				const rotation = parseSshKeyRotationEvent(ev.data);
+				contracts = contracts.map((c) =>
+					c.contract_id === rotation.contract_id
+						? { ...c, ssh_key_rotation_requested_at_ns: undefined }
+						: c
+				);
+			} catch (e) {
+				console.error('[Rentals] Failed to parse ssh_key_rotation_complete SSE event:', e);
 			}
 		});
 		eventSource.onopen = () => { sseConnected = true; };


### PR DESCRIPTION
## Summary

Extends the `/api/v1/users/{pubkey}/contract-events` SSE endpoint to emit `ssh_key_rotation` and `ssh_key_rotation_complete` events alongside existing `contract-status` events. This enables real-time SSH key rotation status updates on the rentals list page without polling.

## Changes

### Backend
- **`api/src/openapi/providers.rs`**: Refactored the `contract_status_events` SSE handler:
  - Extracted the 5-element unfold tuple into a named `SseState` struct (`db`, `pk`, `prev_snapshot`, `poll_count`, `last_rotation_event_ns`)
  - Added rotation event polling via `get_ssh_key_rotation_events_for_user()` with `last_rotation_event_ns` tracking to avoid re-emitting seen events
- **`api/src/database/contracts/extensions.rs`** (from prep commit): `get_ssh_key_rotation_events_for_user()` query fetching rotation events for all of a user's contracts after a given timestamp

### Frontend (from prep commit)
- **`contract-sse.ts`**: Added `SshKeyRotationEvent` interface and `parseSshKeyRotationEvent()` parser
- **`rentals/+page.svelte`**: Added SSE listeners for both rotation event types that update `ssh_key_rotation_requested_at_ns` reactively

### Tests
- **Integration test**: `test_get_ssh_key_rotation_events_for_user_returns_rotation_events` — exercises the full DB query: insert contracts, request/complete rotations, verify filtering by `requester_pubkey` and `after_ns`
- **Unit tests** (from prep): 3 SSE event format tests + 8 frontend parser tests

## Backend Validation

- Integration test runs against real PostgreSQL (Docker) via `TEST_DATABASE_URL`
- All 5 SSH key rotation related tests pass: 2 DB integration + 3 SSE format
- `cargo clippy -p api --tests` clean
- Frontend vitest `contract-sse.test.ts` (30 tests) all pass
- .sqlx cache regenerated and verified up to date

## Test Plan

1. Connect to SSE endpoint as an authenticated user with an active contract
2. Request SSH key rotation via the contract detail page
3. Verify `ssh_key_rotation` event appears in the SSE stream
4. Complete the rotation via dc-agent
5. Verify `ssh_key_rotation_complete` event appears in the SSE stream
6. Verify the rentals list page updates the rotation status indicator in real-time

Closes #195