### PR TITLE
feat(#345): add default_image existence check to Docker verify_setup()

### DIFF
--- a/dc-agent/src/main.rs
+++ b/dc-agent/src/main.rs
@@ -2749,6 +2749,9 @@ async fn run_doctor(config: Config, verify_api: bool, test_provision: bool) -> R
             if verification.storage_accessible == Some(true) {
                 println!("  [ok] Docker image storage accessible");
             }
+            if verification.template_exists == Some(true) {
+                println!("  [ok] Default image '{}' exists", docker.default_image);
+            }
             if !verification.errors.is_empty() {
                 println!();
                 for error in &verification.errors {

--- a/dc-agent/src/provisioner/docker.rs
+++ b/dc-agent/src/provisioner/docker.rs
@@ -522,8 +522,22 @@ impl Provisioner for DockerProvisioner {
         }
 
         match self.client.list_images::<String>(None).await {
-            Ok(_) => {
+            Ok(images) => {
                 result.storage_accessible = Some(true);
+
+                let image_exists = images.iter().any(|img| {
+                    img.repo_tags.iter().any(|t| t == &self.config.default_image)
+                });
+
+                if image_exists {
+                    result.template_exists = Some(true);
+                } else {
+                    result.template_exists = Some(false);
+                    result.errors.push(format!(
+                        "Default image '{}' not found locally. Pull it with: docker pull {}",
+                        self.config.default_image, self.config.default_image
+                    ));
+                }
             }
             Err(e) => {
                 result.storage_accessible = Some(false);
@@ -550,13 +564,17 @@ impl DockerProvisioner {
     }
 
     fn new_for_mockito(url: String) -> Self {
+        Self::new_for_mockito_with_image(url, "ubuntu:22.04".to_string())
+    }
+
+    fn new_for_mockito_with_image(url: String, default_image: String) -> Self {
         let client = Docker::connect_with_http(&url, 120, bollard::API_DEFAULT_VERSION)
             .expect("connect_with_http should not fail");
         Self {
             config: DockerConfig {
                 socket_path: String::new(),
                 network: "bridge".to_string(),
-                default_image: "ubuntu:22.04".to_string(),
+                default_image,
                 ssh_port: 22,
             },
             client,

--- a/dc-agent/src/provisioner/docker_tests.rs
+++ b/dc-agent/src/provisioner/docker_tests.rs
@@ -408,3 +408,99 @@ async fn test_pull_image_propagates_list_error() {
         "pull_image_if_needed() should propagate list_images error"
     );
 }
+
+#[tokio::test]
+async fn test_verify_setup_image_found() {
+    let mut server = mockito::Server::new_async().await;
+    let _ping = server
+        .mock("GET", "/_ping")
+        .with_status(200)
+        .with_body("OK")
+        .create_async()
+        .await;
+    let _images = server
+        .mock("GET", "/images/json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ubuntu:22.04","ubuntu:latest"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .create_async()
+        .await;
+
+    let prov = DockerProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.api_reachable, Some(true));
+    assert_eq!(result.storage_accessible, Some(true));
+    assert_eq!(result.template_exists, Some(true));
+    assert!(result.errors.is_empty(), "Expected no errors, got: {:?}", result.errors);
+}
+
+#[tokio::test]
+async fn test_verify_setup_image_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let _ping = server
+        .mock("GET", "/_ping")
+        .with_status(200)
+        .with_body("OK")
+        .create_async()
+        .await;
+    let _images = server
+        .mock("GET", "/images/json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"Id":"sha256:def","RepoTags":["alpine:3.19"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .create_async()
+        .await;
+
+    let prov = DockerProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.template_exists, Some(false));
+    assert_eq!(result.errors.len(), 1);
+    let err = &result.errors[0];
+    assert!(
+        err.contains("ubuntu:22.04"),
+        "Error should mention the image name: {}",
+        err
+    );
+    assert!(
+        err.contains("docker pull"),
+        "Error should suggest docker pull: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_verify_setup_image_not_found_custom_image() {
+    let mut server = mockito::Server::new_async().await;
+    let _ping = server
+        .mock("GET", "/_ping")
+        .with_status(200)
+        .with_body("OK")
+        .create_async()
+        .await;
+    let _images = server
+        .mock("GET", "/images/json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[]"#)
+        .create_async()
+        .await;
+
+    let prov = DockerProvisioner::new_for_mockito_with_image(
+        server.url(),
+        "my-registry/custom:latest".to_string(),
+    );
+    let result = prov.verify_setup().await;
+    assert_eq!(result.template_exists, Some(false));
+    assert_eq!(result.errors.len(), 1);
+    let err = &result.errors[0];
+    assert!(
+        err.contains("my-registry/custom:latest"),
+        "Error should mention the custom image name: {}",
+        err
+    );
+    assert!(
+        err.contains("docker pull my-registry/custom:latest"),
+        "Error should suggest the exact docker pull command: {}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `default_image` existence check to the Docker provisioner's `verify_setup()` method, following the Proxmox `template_exists` pattern.

## Changes

- **`dc-agent/src/provisioner/docker.rs`**: After the `storage_accessible` check, inspects whether `self.config.default_image` exists on the Docker daemon by matching repo tags from `list_images`. Sets `result.template_exists = Some(true/false)`. On false, pushes an error with the image name and a `docker pull` suggestion.
- **`dc-agent/src/main.rs`**: Updates the `doctor` command output to print `template_exists` status for the Docker provisioner (`[ok] Default image '...' exists`).
- **`dc-agent/src/provisioner/docker_tests.rs`**: Adds 3 mockito-based tests:
  - `test_verify_setup_image_found` — image present in daemon, `template_exists = Some(true)`, no errors
  - `test_verify_setup_image_not_found` — image absent, `template_exists = Some(false)`, error mentions image name and `docker pull`
  - `test_verify_setup_image_not_found_custom_image` — custom image name, error correctly references the configured image

## Test plan

- [x] `cargo clippy -p dc-agent --tests` — clean
- [x] `cargo nextest run -p dc-agent` — 173/173 pass (1 skipped, pre-existing)
- [ ] Manual: run `dc-agent doctor` with Docker provisioner configured, verify output shows `[ok] Default image '...' exists` or `[FAILED]` with pull suggestion

Parent: #122