### PR TITLE
fix(#346): support IPv6 in the Docker provisioner

### DIFF
--- a/dc-agent/src/main.rs
+++ b/dc-agent/src/main.rs
@@ -1338,6 +1338,9 @@ async fn run_agent(config: Config) -> Result<()> {
             verification.errors.join("\n  - ")
         );
     }
+    for warning in &verification.warnings {
+        warn!(warning = %warning, "Provisioner setup warning");
+    }
     info!("Provisioner setup verified successfully");
 
     // Initialize gateway manager if configured
@@ -2760,6 +2763,12 @@ async fn run_doctor(config: Config, verify_api: bool, test_provision: bool) -> R
             }
             if verification.template_exists == Some(true) {
                 println!("  [ok] Default image '{}' exists", docker.default_image);
+            }
+            if !verification.warnings.is_empty() {
+                println!();
+                for warning in &verification.warnings {
+                    println!("  [WARN] {}", warning);
+                }
             }
             if !verification.errors.is_empty() {
                 println!();

--- a/dc-agent/src/provisioner/docker.rs
+++ b/dc-agent/src/provisioner/docker.rs
@@ -226,8 +226,6 @@ impl DockerProvisioner {
     fn extract_ipv6_address(&self, inspect: &ContainerInspectResponse) -> Option<String> {
         let network_settings = inspect.network_settings.as_ref()?;
 
-        // PoC: real Docker inspect data exposes IPv6 on the per-network endpoint,
-        // so prefer the configured network and only fall back to Docker's deprecated field.
         network_settings
             .networks
             .as_ref()
@@ -244,6 +242,25 @@ impl DockerProvisioner {
             })
     }
 
+    fn extract_ip_address(&self, inspect: &ContainerInspectResponse) -> Option<String> {
+        let network_settings = inspect.network_settings.as_ref()?;
+
+        network_settings
+            .networks
+            .as_ref()
+            .and_then(|networks| networks.get(&self.config.network))
+            .and_then(|network| network.ip_address.as_ref())
+            .filter(|ip| !ip.is_empty())
+            .cloned()
+            .or_else(|| {
+                network_settings
+                    .ip_address
+                    .as_ref()
+                    .filter(|ip| !ip.is_empty())
+                    .cloned()
+            })
+    }
+
     fn container_to_instance(
         &self,
         inspect: &ContainerInspectResponse,
@@ -254,12 +271,7 @@ impl DockerProvisioner {
             None => return None, // Completely empty inspect response; Docker always sets a name
         };
 
-        let ip = inspect
-            .network_settings
-            .as_ref()
-            .and_then(|ns| ns.ip_address.as_ref())
-            .filter(|ip| !ip.is_empty())
-            .cloned();
+        let ip = self.extract_ip_address(inspect);
 
         let host_ssh_port = inspect
             .network_settings
@@ -400,6 +412,7 @@ impl Provisioner for DockerProvisioner {
         tracing::info!(
             id = %id,
             ip = ?instance.ip_address,
+            ipv6 = ?instance.ipv6_address,
             ssh_port = instance.ssh_port,
             "Container provisioned successfully"
         );
@@ -663,6 +676,27 @@ impl Provisioner for DockerProvisioner {
                 result
                     .errors
                     .push(format!("Cannot list Docker images: {:#}", e));
+            }
+        }
+
+        match self
+            .client
+            .inspect_network::<String>(&self.config.network, None)
+            .await
+        {
+            Ok(network) => {
+                if !network.enable_ipv6.unwrap_or(false) {
+                    result.warnings.push(format!(
+                        "Docker network '{}' does not have IPv6 enabled. Containers will not receive IPv6 addresses. Enable with: docker network create --ipv6 {}",
+                        self.config.network, self.config.network
+                    ));
+                }
+            }
+            Err(e) => {
+                result.warnings.push(format!(
+                    "Cannot inspect Docker network '{}': {:#}. IPv6 support cannot be verified.",
+                    self.config.network, e
+                ));
             }
         }
 

--- a/dc-agent/src/provisioner/docker.rs
+++ b/dc-agent/src/provisioner/docker.rs
@@ -223,6 +223,27 @@ impl DockerProvisioner {
         }
     }
 
+    fn extract_ipv6_address(&self, inspect: &ContainerInspectResponse) -> Option<String> {
+        let network_settings = inspect.network_settings.as_ref()?;
+
+        // PoC: real Docker inspect data exposes IPv6 on the per-network endpoint,
+        // so prefer the configured network and only fall back to Docker's deprecated field.
+        network_settings
+            .networks
+            .as_ref()
+            .and_then(|networks| networks.get(&self.config.network))
+            .and_then(|network| network.global_ipv6_address.as_ref())
+            .filter(|ip| !ip.is_empty())
+            .cloned()
+            .or_else(|| {
+                network_settings
+                    .global_ipv6_address
+                    .as_ref()
+                    .filter(|ip| !ip.is_empty())
+                    .cloned()
+            })
+    }
+
     fn container_to_instance(
         &self,
         inspect: &ContainerInspectResponse,
@@ -268,7 +289,7 @@ impl DockerProvisioner {
         Some(Instance {
             external_id: id.to_string(),
             ip_address: ip,
-            ipv6_address: None,
+            ipv6_address: self.extract_ipv6_address(inspect),
             public_ip: None,
             ssh_port: host_ssh_port.unwrap_or(self.config.ssh_port),
             root_password: None,

--- a/dc-agent/src/provisioner/docker.rs
+++ b/dc-agent/src/provisioner/docker.rs
@@ -687,8 +687,8 @@ impl Provisioner for DockerProvisioner {
             Ok(network) => {
                 if !network.enable_ipv6.unwrap_or(false) {
                     result.warnings.push(format!(
-                        "Docker network '{}' does not have IPv6 enabled. Containers will not receive IPv6 addresses. Enable with: docker network create --ipv6 {}",
-                        self.config.network, self.config.network
+                        "Docker network '{}' does not have IPv6 enabled. Containers will not receive IPv6 addresses. Enable IPv6 on that network or switch to a user-defined IPv6 network created with `docker network create --ipv6 <name>`.",
+                        self.config.network
                     ));
                 }
             }

--- a/dc-agent/src/provisioner/docker_tests.rs
+++ b/dc-agent/src/provisioner/docker_tests.rs
@@ -237,6 +237,143 @@ fn test_container_to_instance_prefers_configured_network_ipv6() {
 }
 
 #[test]
+fn test_container_to_instance_prefers_configured_network_ipv4() {
+    let config = DockerConfig {
+        network: "dc346-ipv6-net".to_string(),
+        ..default_config()
+    };
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.99".to_string()),
+            networks: Some(HashMap::from([(
+                "dc346-ipv6-net".to_string(),
+                EndpointSettings {
+                    ip_address: Some("192.168.16.2".to_string()),
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert_eq!(instance.ip_address.as_deref(), Some("192.168.16.2"));
+}
+
+#[test]
+fn test_extract_ipv6_falls_back_to_deprecated_field() {
+    let config = DockerConfig {
+        network: "dc346-ipv6-net".to_string(),
+        ..default_config()
+    };
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.2".to_string()),
+            global_ipv6_address: Some("fd00:deprecated::1".to_string()),
+            networks: Some(HashMap::from([(
+                "dc346-ipv6-net".to_string(),
+                EndpointSettings {
+                    global_ipv6_address: None,
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert_eq!(instance.ipv6_address.as_deref(), Some("fd00:deprecated::1"));
+}
+
+#[test]
+fn test_extract_ipv4_falls_back_to_deprecated_field() {
+    let config = DockerConfig {
+        network: "dc346-ipv6-net".to_string(),
+        ..default_config()
+    };
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.2".to_string()),
+            networks: Some(HashMap::from([(
+                "dc346-ipv6-net".to_string(),
+                EndpointSettings {
+                    ip_address: None,
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert_eq!(instance.ip_address.as_deref(), Some("172.17.0.2"));
+}
+
+#[test]
+fn test_extract_ipv6_returns_none_when_no_ipv6() {
+    let config = default_config();
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.2".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert!(instance.ipv6_address.is_none());
+}
+
+#[test]
+fn test_extract_ipv6_ignores_empty_strings() {
+    let config = default_config();
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.2".to_string()),
+            global_ipv6_address: Some("".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert!(instance.ipv6_address.is_none());
+}
+
+#[test]
+fn test_extract_ipv6_no_network_settings_returns_none() {
+    let config = default_config();
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: None,
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert!(instance.ipv6_address.is_none());
+}
+
+#[test]
 fn test_container_to_instance_no_ip() {
     let config = default_config();
     let prov = DockerProvisioner::new_for_test(config);
@@ -444,6 +581,13 @@ async fn test_verify_setup_image_found() {
         .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ghcr.io/decent-stuff/dc-agent-ssh:latest"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
         .create_async()
         .await;
+    let _network = server
+        .mock("GET", "/networks/bridge")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"EnableIPv6":true}"#)
+        .create_async()
+        .await;
 
     let prov = DockerProvisioner::new_for_mockito(server.url());
     let result = prov.verify_setup().await;
@@ -454,6 +598,14 @@ async fn test_verify_setup_image_found() {
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
         result.errors
+    );
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("IPv6") || warning.contains("inspect Docker network")),
+        "Expected no IPv6 warnings, got: {:?}",
+        result.warnings
     );
 }
 
@@ -471,6 +623,13 @@ async fn test_verify_setup_image_not_found() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"[{"Id":"sha256:def","RepoTags":["alpine:3.19"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .create_async()
+        .await;
+    let _network = server
+        .mock("GET", "/networks/bridge")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"EnableIPv6":true}"#)
         .create_async()
         .await;
 
@@ -505,6 +664,13 @@ async fn test_verify_setup_image_not_found_custom_image() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"[]"#)
+        .create_async()
+        .await;
+    let _network = server
+        .mock("GET", "/networks/bridge")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"EnableIPv6":true}"#)
         .create_async()
         .await;
 
@@ -595,7 +761,7 @@ MemFree:         2048000 kB\n\
 MemAvailable:    8192000 kB\n\
 Buffers:          204800 kB\n";
     let avail = super::parse_mem_available_mb(meminfo).expect("should parse MemAvailable");
-    assert_eq!(avail, 8000); // 8192000 kB / 1024 = 8000 MB
+    assert_eq!(avail, 8000);
 }
 
 #[test]
@@ -725,5 +891,91 @@ async fn test_collect_resources_returns_none_on_info_error() {
     assert!(
         resources.is_none(),
         "collect_resources() must return None when Docker info fails"
+    );
+}
+
+// ── Ticket 346: IPv6 verification warnings ────────────────────────────────
+
+#[tokio::test]
+async fn test_verify_setup_warns_when_network_ipv6_disabled() {
+    let mut server = mockito::Server::new_async().await;
+    let _ping = server
+        .mock("GET", "/_ping")
+        .with_status(200)
+        .with_body("OK")
+        .create_async()
+        .await;
+    let _images = server
+        .mock("GET", "/images/json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ubuntu:22.04"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .create_async()
+        .await;
+    let _network = server
+        .mock("GET", "/networks/bridge")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"EnableIPv6":false}"#)
+        .create_async()
+        .await;
+
+    let prov = DockerProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("does not have IPv6 enabled")),
+        "Expected IPv6-disabled warning, got: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn test_verify_setup_warns_when_network_cannot_be_inspected() {
+    let mut server = mockito::Server::new_async().await;
+    let _ping = server
+        .mock("GET", "/_ping")
+        .with_status(200)
+        .with_body("OK")
+        .create_async()
+        .await;
+    let _images = server
+        .mock("GET", "/images/json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ubuntu:22.04"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .create_async()
+        .await;
+    let _network = server
+        .mock("GET", "/networks/bridge")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"message":"network bridge not found"}"#)
+        .create_async()
+        .await;
+
+    let prov = DockerProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Cannot inspect Docker network 'bridge'")),
+        "Expected network inspection warning, got: {:?}",
+        result.warnings
     );
 }

--- a/dc-agent/src/provisioner/docker_tests.rs
+++ b/dc-agent/src/provisioner/docker_tests.rs
@@ -909,7 +909,7 @@ async fn test_verify_setup_warns_when_network_ipv6_disabled() {
         .mock("GET", "/images/json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ubuntu:22.04"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ghcr.io/decent-stuff/dc-agent-ssh:latest"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
         .create_async()
         .await;
     let _network = server
@@ -951,7 +951,7 @@ async fn test_verify_setup_warns_when_network_cannot_be_inspected() {
         .mock("GET", "/images/json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ubuntu:22.04"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
+        .with_body(r#"[{"Id":"sha256:abc","RepoTags":["ghcr.io/decent-stuff/dc-agent-ssh:latest"],"Created":0,"Size":0,"VirtualSize":0,"SharedSize":0,"Containers":0,"Labels":{},"ParentId":"","RepoDigests":[]}]"#)
         .create_async()
         .await;
     let _network = server

--- a/dc-agent/src/provisioner/docker_tests.rs
+++ b/dc-agent/src/provisioner/docker_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use bollard::models::ContainerStateStatusEnum;
-use bollard::service::{ContainerInspectResponse, ContainerState, NetworkSettings};
+use bollard::service::{
+    ContainerInspectResponse, ContainerState, EndpointSettings, NetworkSettings,
+};
 
 fn default_config() -> DockerConfig {
     DockerConfig {
@@ -203,6 +205,35 @@ fn test_container_to_instance_running() {
     assert_eq!(instance.ip_address.as_deref(), Some("172.17.0.2"));
     assert_eq!(instance.ssh_port, 32768);
     assert!(instance.additional_details.is_some());
+}
+
+#[test]
+fn test_container_to_instance_prefers_configured_network_ipv6() {
+    let config = DockerConfig {
+        network: "dc346-ipv6-net".to_string(),
+        ..default_config()
+    };
+    let prov = DockerProvisioner::new_for_test(config);
+
+    let inspect = ContainerInspectResponse {
+        name: Some("/dc-test-contract".to_string()),
+        network_settings: Some(NetworkSettings {
+            ip_address: Some("172.17.0.2".to_string()),
+            global_ipv6_address: Some("fd00:old::99".to_string()),
+            networks: Some(HashMap::from([(
+                "dc346-ipv6-net".to_string(),
+                EndpointSettings {
+                    global_ipv6_address: Some("fd00:346::2".to_string()),
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let instance = prov.container_to_instance(&inspect, "abc123").unwrap();
+    assert_eq!(instance.ipv6_address.as_deref(), Some("fd00:346::2"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- read Docker instance IPv4 and IPv6 from `NetworkSettings.Networks[configured-network]` first, then fall back to Docker's deprecated top-level fields
- warn from `dc-agent doctor` and startup verification when the configured Docker network cannot provide or verify IPv6
- add Docker provisioner tests for per-network IPv4/IPv6 extraction, fallback behavior, and IPv6 verification warnings

## Test Plan
- `cargo clippy -p dc-agent --tests -- -D warnings`
- `cargo test -p dc-agent`
- `cargo run -p dc-agent -- --config .tmp-ticket-346.toml test-provision --contract-id ticket-346-live`
  - validated against a real IPv6-enabled Docker bridge network and observed `IPv4: 192.168.16.2` plus `IPv6: fd00:346::2`
- `cargo run -p dc-agent -- --config .tmp-ticket-346.toml doctor --no-verify-api --no-test-provision`
  - confirmed the new Docker IPv6 warning is printed for the default `bridge` network before the expected failure from the throwaway dummy API auth config