### PR TITLE
feat(#349): DigitalOcean provisioner for dc-agent

### DIFF
--- a/dc-agent/src/config.rs
+++ b/dc-agent/src/config.rs
@@ -119,6 +119,7 @@ pub enum ProvisionerConfig {
     Script(ScriptConfig),
     Manual(ManualConfig),
     Docker(DockerConfig),
+    DigitalOcean(DigitalOceanConfig),
 }
 
 impl ProvisionerConfig {
@@ -150,12 +151,20 @@ impl ProvisionerConfig {
         }
     }
 
+    pub fn as_digitalocean(&self) -> Option<&DigitalOceanConfig> {
+        match self {
+            ProvisionerConfig::DigitalOcean(cfg) => Some(cfg),
+            _ => None,
+        }
+    }
+
     pub fn type_name(&self) -> &'static str {
         match self {
             ProvisionerConfig::Proxmox(_) => "proxmox",
             ProvisionerConfig::Script(_) => "script",
             ProvisionerConfig::Manual(_) => "manual",
             ProvisionerConfig::Docker(_) => "docker",
+            ProvisionerConfig::DigitalOcean(_) => "digitalocean",
         }
     }
 }
@@ -199,6 +208,13 @@ struct RawProvisionerConfig {
     socket_path: Option<String>,
     network: Option<String>,
     default_image: Option<String>,
+    // Nested subsection for digitalocean
+    digitalocean: Option<DigitalOceanConfig>,
+    // Flat fields for digitalocean
+    api_token: Option<String>,
+    do_size: Option<String>,
+    do_region: Option<String>,
+    do_image: Option<String>,
 }
 
 fn deserialize_provisioner<'de, D>(deserializer: D) -> Result<ProvisionerConfig, D::Error>
@@ -316,9 +332,25 @@ where
             };
             Ok(ProvisionerConfig::Docker(config))
         }
+        "digitalocean" => {
+            let config = if let Some(nested) = raw.digitalocean {
+                nested
+            } else {
+                let api_token = raw
+                    .api_token
+                    .ok_or_else(|| serde::de::Error::missing_field("api_token"))?;
+                DigitalOceanConfig {
+                    api_token,
+                    default_size: raw.do_size.unwrap_or_else(default_do_size),
+                    default_region: raw.do_region.unwrap_or_else(default_do_region),
+                    default_image: raw.do_image.unwrap_or_else(default_do_image),
+                }
+            };
+            Ok(ProvisionerConfig::DigitalOcean(config))
+        }
         other => Err(serde::de::Error::unknown_variant(
             other,
-            &["proxmox", "script", "manual", "docker"],
+            &["proxmox", "script", "manual", "docker", "digitalocean"],
         )),
     }
 }
@@ -376,6 +408,22 @@ pub struct DockerConfig {
     /// SSH port inside the container (default: 22)
     #[serde(default = "default_docker_ssh_port")]
     pub ssh_port: u16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DigitalOceanConfig {
+    /// DigitalOcean API token (required)
+    pub api_token: String,
+    /// Default droplet size slug (default: "s-1vcpu-1gb")
+    #[serde(default = "default_do_size")]
+    pub default_size: String,
+    /// Default region slug (default: "nyc3")
+    #[serde(default = "default_do_region")]
+    pub default_region: String,
+    /// Default image slug (default: "ubuntu-24-04-x64")
+    #[serde(default = "default_do_image")]
+    pub default_image: String,
 }
 
 /// Placeholder patterns that indicate unconfigured values
@@ -489,6 +537,13 @@ impl Config {
                     &mut placeholders_found,
                 );
             }
+            ProvisionerConfig::DigitalOcean(do_config) => {
+                Self::check_placeholder(
+                    &do_config.api_token,
+                    "provisioner.digitalocean.api_token",
+                    &mut placeholders_found,
+                );
+            }
         }
 
         // Check additional provisioners
@@ -518,6 +573,13 @@ impl Config {
                     Self::check_placeholder(
                         &docker.socket_path,
                         &format!("additional_provisioners[{}].socket_path", idx),
+                        &mut placeholders_found,
+                    );
+                }
+                ProvisionerConfig::DigitalOcean(do_config) => {
+                    Self::check_placeholder(
+                        &do_config.api_token,
+                        &format!("additional_provisioners[{}].api_token", idx),
                         &mut placeholders_found,
                     );
                 }
@@ -596,6 +658,18 @@ fn default_docker_image() -> String {
 
 fn default_docker_ssh_port() -> u16 {
     22
+}
+
+fn default_do_size() -> String {
+    "s-1vcpu-1gb".to_string()
+}
+
+fn default_do_region() -> String {
+    "nyc3".to_string()
+}
+
+fn default_do_image() -> String {
+    "ubuntu-24-04-x64".to_string()
 }
 
 /// Deserialize additional provisioners from [[additional_provisioners]] array
@@ -691,10 +765,26 @@ where
                 };
                 ProvisionerConfig::Docker(config)
             }
+            "digitalocean" => {
+                let config = if let Some(nested) = raw.digitalocean {
+                    nested
+                } else {
+                    let api_token = raw
+                        .api_token
+                        .ok_or_else(|| serde::de::Error::missing_field("api_token"))?;
+                    DigitalOceanConfig {
+                        api_token,
+                        default_size: raw.do_size.unwrap_or_else(default_do_size),
+                        default_region: raw.do_region.unwrap_or_else(default_do_region),
+                        default_image: raw.do_image.unwrap_or_else(default_do_image),
+                    }
+                };
+                ProvisionerConfig::DigitalOcean(config)
+            }
             other => {
                 return Err(serde::de::Error::unknown_variant(
                     other,
-                    &["proxmox", "script", "manual", "docker"],
+                    &["proxmox", "script", "manual", "docker", "digitalocean"],
                 ))
             }
         };

--- a/dc-agent/src/main.rs
+++ b/dc-agent/src/main.rs
@@ -3064,9 +3064,53 @@ async fn run_doctor(config: Config, verify_api: bool, test_provision: bool) -> R
                     }
                 }
             }
+            ProvisionerConfig::DigitalOcean(_) => {
+                let test_contract_id = format!("doctor-test-{}", std::process::id());
+                let request = ProvisionRequest {
+                    contract_id: test_contract_id.clone(),
+                    offering_id: "doctor-test".to_string(),
+                    cpu_cores: Some(1),
+                    memory_mb: Some(1024),
+                    storage_gb: None,
+                    requester_ssh_pubkey: None,
+                    instance_config: None,
+                    post_provision_script: None,
+                };
+
+                println!("  Creating test DigitalOcean droplet...");
+                println!("  WARNING: This will create and destroy a real droplet (billed hourly).");
+                match provisioner.provision(&request).await {
+                    Ok(instance) => {
+                        println!("[ok] Test droplet created: {}", instance.external_id);
+                        if let Some(ip) = &instance.ip_address {
+                            println!("  IP address: {}", ip);
+                        }
+                        println!("  Terminating test droplet...");
+                        match provisioner.terminate(&instance.external_id).await {
+                            Ok(()) => println!("[ok] Test droplet terminated successfully"),
+                            Err(e) => {
+                                println!("[WARN] Droplet created but termination failed: {:#}", e);
+                                println!(
+                                    "  Manual cleanup may be required for droplet {}",
+                                    instance.external_id
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        println!("[FAILED] Provisioning test failed: {:#}", e);
+                        println!();
+                        println!("Possible causes:");
+                        println!("  - Invalid API token or insufficient permissions");
+                        println!("  - Account droplet limit reached");
+                        println!("  - Invalid region or size in config");
+                        return Err(anyhow::anyhow!("Provisioning test failed: {:#}", e));
+                    }
+                }
+            }
             _ => {
                 println!(
-                    "  [skip] --test-provision only supported for Proxmox and Docker provisioners"
+                    "  [skip] --test-provision only supported for Proxmox, Docker, and DigitalOcean provisioners"
                 );
             }
         }

--- a/dc-agent/src/main.rs
+++ b/dc-agent/src/main.rs
@@ -7,8 +7,9 @@ use dc_agent::{
     orphan_tracker::OrphanTracker,
     post_provision::execute_post_provision_script,
     provisioner::{
-        docker::DockerProvisioner, manual::ManualProvisioner, proxmox::ProxmoxProvisioner,
-        script::ScriptProvisioner, ProvisionRequest, Provisioner,
+        digitalocean::DigitalOceanProvisioner, docker::DockerProvisioner,
+        manual::ManualProvisioner, proxmox::ProxmoxProvisioner, script::ScriptProvisioner,
+        ProvisionRequest, Provisioner,
     },
     registration::{default_agent_dir, generate_agent_keypair},
     setup::{detect_public_ip, GatewaySetup},
@@ -2581,6 +2582,10 @@ fn create_provisioner_from_config(prov_config: &ProvisionerConfig) -> Result<Box
             info!("Creating Docker provisioner");
             Ok(Box::new(DockerProvisioner::new(docker.clone())?))
         }
+        ProvisionerConfig::DigitalOcean(do_config) => {
+            info!("Creating DigitalOcean provisioner");
+            Ok(Box::new(DigitalOceanProvisioner::new(do_config.clone())?))
+        }
     }
 }
 
@@ -2763,6 +2768,29 @@ async fn run_doctor(config: Config, verify_api: bool, test_provision: bool) -> R
                 }
                 return Err(anyhow::anyhow!(
                     "Docker setup verification failed with {} error(s)",
+                    verification.errors.len()
+                ));
+            }
+        }
+        ProvisionerConfig::DigitalOcean(do_config) => {
+            println!("Provisioner: DigitalOcean");
+            println!("  Default size: {}", do_config.default_size);
+            println!("  Default region: {}", do_config.default_region);
+            println!("  Default image: {}", do_config.default_image);
+            println!("  API token: {}...", &do_config.api_token.chars().take(8).collect::<String>());
+            println!();
+            println!("Verifying DigitalOcean setup...");
+            let verification = provisioner.verify_setup().await;
+            if verification.api_reachable == Some(true) {
+                println!("  [ok] DigitalOcean API reachable");
+            }
+            if !verification.errors.is_empty() {
+                println!();
+                for error in &verification.errors {
+                    println!("  [FAILED] {}", error);
+                }
+                return Err(anyhow::anyhow!(
+                    "DigitalOcean setup verification failed with {} error(s)",
                     verification.errors.len()
                 ));
             }

--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -1,0 +1,653 @@
+use super::{
+    HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance, SetupVerification,
+};
+use crate::config::DigitalOceanConfig;
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing;
+
+const DO_API_BASE: &str = "https://api.digitalocean.com/v2";
+const DC_AGENT_TAG: &str = "dc-agent";
+
+// ── DO API response types ───────────────────────────────────────────────────
+// These are based on the DigitalOcean API v2 specification:
+// https://docs.digitalocean.com/reference/api/api-reference/
+
+#[derive(Debug, Deserialize)]
+struct DropletsResponse {
+    droplets: Vec<Droplet>,
+    meta: Option<Meta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DropletResponse {
+    droplet: Droplet,
+}
+
+#[derive(Debug, Deserialize)]
+struct Droplet {
+    id: i64,
+    name: String,
+    status: String,
+    memory: i64,
+    vcpus: i32,
+    disk: i64,
+    locked: bool,
+    created_at: String,
+    #[serde(default)]
+    networks: Networks,
+    region: DoRegion,
+    size_slug: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    image: Option<DoImage>,
+    #[serde(default)]
+    features: Vec<String>,
+}
+
+impl Droplet {
+    fn public_ipv4(&self) -> Option<String> {
+        self.networks
+            .v4
+            .iter()
+            .find(|n| n.network_type == "public")
+            .map(|n| n.ip_address.clone())
+    }
+
+    fn public_ipv6(&self) -> Option<String> {
+        self.networks
+            .v6
+            .iter()
+            .find(|n| n.network_type == "public")
+            .map(|n| n.ip_address.clone())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Networks {
+    #[serde(default)]
+    v4: Vec<NetworkV4>,
+    #[serde(default)]
+    v6: Vec<NetworkV6>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NetworkV4 {
+    ip_address: String,
+    netmask: String,
+    gateway: String,
+    #[serde(rename = "type")]
+    network_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NetworkV6 {
+    ip_address: String,
+    netmask: i32,
+    gateway: String,
+    #[serde(rename = "type")]
+    network_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoRegion {
+    name: String,
+    slug: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoImage {
+    id: i64,
+    name: String,
+    slug: Option<String>,
+    distribution: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SizesResponse {
+    sizes: Vec<Size>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Size {
+    slug: String,
+    memory: i64,
+    vcpus: i32,
+    disk: i64,
+    price_monthly: f64,
+    price_hourly: f64,
+    available: bool,
+    #[serde(default)]
+    regions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegionsResponse {
+    regions: Vec<RegionDetail>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegionDetail {
+    name: String,
+    slug: String,
+    available: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImagesResponse {
+    images: Vec<ImageDetail>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImageDetail {
+    id: i64,
+    name: String,
+    slug: Option<String>,
+    distribution: String,
+    public: bool,
+    available: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SshKeyResponse {
+    ssh_key: SshKey,
+}
+
+#[derive(Debug, Deserialize)]
+struct SshKey {
+    id: i64,
+    name: String,
+    fingerprint: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoActionResponse {
+    action: DoAction,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoAction {
+    id: i64,
+    status: String,
+    #[serde(rename = "type")]
+    action_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Meta {
+    total: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoErrorResponse {
+    id: String,
+    message: String,
+}
+
+// ── Create droplet request ──────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct CreateDropletRequest {
+    name: String,
+    region: String,
+    size: String,
+    image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ssh_keys: Option<Vec<i64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_data: Option<String>,
+}
+
+fn droplet_name(contract_id: &str) -> String {
+    format!("dc-{}", contract_id)
+}
+
+fn extract_contract_id(name: &str) -> Option<String> {
+    name.strip_prefix("dc-").map(String::from)
+}
+
+// ── DigitalOceanProvisioner ─────────────────────────────────────────────────
+
+pub struct DigitalOceanProvisioner {
+    config: DigitalOceanConfig,
+    client: Client,
+}
+
+impl DigitalOceanProvisioner {
+    pub fn new(config: DigitalOceanConfig) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("Failed to build HTTP client for DigitalOcean API")?;
+        Ok(Self { config, client })
+    }
+
+    fn request_builder(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", DO_API_BASE, path);
+        self.client
+            .request(method, &url)
+            .bearer_auth(&self.config.api_token)
+            .header("Content-Type", "application/json")
+    }
+
+    async fn handle_error(response: reqwest::Response) -> Result<()> {
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        let body = response.text().await.unwrap_or_default();
+        bail!(
+            "DigitalOcean API error: status={}, body={}",
+            status,
+            body
+        );
+    }
+
+    async fn get_droplet(&self, droplet_id: i64) -> Result<Option<Droplet>> {
+        let resp = self
+            .request_builder(reqwest::Method::GET, &format!("/v2/droplets/{}", droplet_id))
+            .send()
+            .await
+            .with_context(|| format!("Failed to GET droplet {}", droplet_id))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to get droplet {}: status={}, body={}", droplet_id, status, body);
+        }
+
+        let droplet_resp: DropletResponse = resp
+            .json()
+            .await
+            .context("Failed to parse droplet response")?;
+        Ok(Some(droplet_resp.droplet))
+    }
+
+    async fn wait_for_droplet_active(&self, droplet_id: i64, max_retries: u32) -> Result<Droplet> {
+        for attempt in 0..max_retries {
+            let droplet = self
+                .get_droplet(droplet_id)
+                .await?
+                .context("Droplet disappeared while waiting for active state")?;
+
+            if droplet.status == "active" {
+                tracing::info!(droplet_id, "Droplet is active");
+                return Ok(droplet);
+            }
+
+            tracing::debug!(
+                droplet_id,
+                status = %droplet.status,
+                attempt,
+                "Waiting for droplet to become active"
+            );
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        bail!(
+            "Droplet {} did not reach 'active' state within {} retries",
+            droplet_id,
+            max_retries
+        );
+    }
+
+    async fn create_ssh_key(&self, name: &str, public_key: &str) -> Result<i64> {
+        #[derive(Serialize)]
+        struct CreateSshKeyRequest {
+            name: String,
+            public_key: String,
+        }
+
+        let resp = self
+            .request_builder(reqwest::Method::POST, "/v2/account/keys")
+            .json(&CreateSshKeyRequest {
+                name: name.to_string(),
+                public_key: public_key.to_string(),
+            })
+            .send()
+            .await
+            .context("Failed to create SSH key on DigitalOcean")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to create SSH key: status={}, body={}", status, body);
+        }
+
+        let key_resp: SshKeyResponse = resp
+            .json()
+            .await
+            .context("Failed to parse SSH key response")?;
+        Ok(key_resp.ssh_key.id)
+    }
+
+    async fn delete_ssh_key(&self, key_id: i64) -> Result<()> {
+        let resp = self
+            .request_builder(reqwest::Method::DELETE, &format!("/v2/account/keys/{}", key_id))
+            .send()
+            .await
+            .with_context(|| format!("Failed to delete SSH key {}", key_id))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            tracing::warn!(key_id, "SSH key not found, assuming already deleted");
+            return Ok(());
+        }
+        Self::handle_error(resp).await
+    }
+
+    fn resolve_size(&self, request: &ProvisionRequest) -> String {
+        request
+            .instance_config
+            .as_ref()
+            .and_then(|c| c.get("size"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| self.config.default_size.clone())
+    }
+
+    fn resolve_region(&self, request: &ProvisionRequest) -> String {
+        request
+            .instance_config
+            .as_ref()
+            .and_then(|c| c.get("region"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| self.config.default_region.clone())
+    }
+
+    fn resolve_image(&self, request: &ProvisionRequest) -> String {
+        request
+            .instance_config
+            .as_ref()
+            .and_then(|c| c.get("image"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| self.config.default_image.clone())
+    }
+
+    fn droplet_to_instance(&self, droplet: &Droplet) -> Instance {
+        Instance {
+            external_id: droplet.id.to_string(),
+            ip_address: droplet.public_ipv4(),
+            ipv6_address: droplet.public_ipv6(),
+            public_ip: droplet.public_ipv4(),
+            ssh_port: 22,
+            root_password: None,
+            additional_details: Some(serde_json::json!({
+                "name": droplet.name,
+                "size_slug": droplet.size_slug,
+                "region": droplet.region.slug,
+                "status": droplet.status,
+                "vcpus": droplet.vcpus,
+                "memory": droplet.memory,
+                "disk": droplet.disk,
+            })),
+            gateway_slug: None,
+            gateway_subdomain: None,
+            gateway_ssh_port: None,
+            gateway_port_range_start: None,
+            gateway_port_range_end: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Provisioner for DigitalOceanProvisioner {
+    async fn provision(&self, request: &ProvisionRequest) -> Result<Instance> {
+        let name = droplet_name(&request.contract_id);
+        let size = self.resolve_size(request);
+        let region = self.resolve_region(request);
+        let image = self.resolve_image(request);
+
+        tracing::info!(
+            contract_id = %request.contract_id,
+            size = %size,
+            region = %region,
+            image = %image,
+            "Provisioning DigitalOcean droplet"
+        );
+
+        let mut ssh_key_ids: Vec<i64> = Vec::new();
+        let mut created_ssh_key_id: Option<i64> = None;
+
+        if let Some(pubkey) = &request.requester_ssh_pubkey {
+            match self
+                .create_ssh_key(&format!("dc-{}", request.contract_id), pubkey)
+                .await
+            {
+                Ok(key_id) => {
+                    tracing::info!(key_id, "Created SSH key on DigitalOcean");
+                    ssh_key_ids.push(key_id);
+                    created_ssh_key_id = Some(key_id);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to create SSH key, provisioning without SSH key");
+                }
+            }
+        }
+
+        let create_req = CreateDropletRequest {
+            name: name.clone(),
+            region: region.clone(),
+            size: size.clone(),
+            image: image.clone(),
+            ssh_keys: if ssh_key_ids.is_empty() {
+                None
+            } else {
+                Some(ssh_key_ids)
+            },
+            tags: Some(vec![DC_AGENT_TAG.to_string(), format!("dc-contract-{}", request.contract_id)]),
+            user_data: None,
+        };
+
+        let resp = self
+            .request_builder(reqwest::Method::POST, "/v2/droplets")
+            .json(&create_req)
+            .send()
+            .await
+            .context("Failed to create droplet")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            if let Some(key_id) = created_ssh_key_id {
+                let _ = self.delete_ssh_key(key_id).await;
+            }
+            bail!(
+                "Failed to create droplet: status={}, body={}",
+                status,
+                body
+            );
+        }
+
+        let droplet_resp: DropletResponse = resp
+            .json()
+            .await
+            .context("Failed to parse create droplet response")?;
+
+        let droplet_id = droplet_resp.droplet.id;
+        tracing::info!(droplet_id, "Droplet created, waiting for active state");
+
+        match self.wait_for_droplet_active(droplet_id, 60).await {
+            Ok(droplet) => {
+                let instance = self.droplet_to_instance(&droplet);
+                tracing::info!(
+                    droplet_id,
+                    ip = ?instance.ip_address,
+                    "Droplet provisioned successfully"
+                );
+                Ok(instance)
+            }
+            Err(e) => {
+                tracing::error!(droplet_id, error = %e, "Droplet failed to become active, cleaning up");
+                let _ = self
+                    .request_builder(
+                        reqwest::Method::DELETE,
+                        &format!("/v2/droplets/{}", droplet_id),
+                    )
+                    .send()
+                    .await;
+                if let Some(key_id) = created_ssh_key_id {
+                    let _ = self.delete_ssh_key(key_id).await;
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn terminate(&self, external_id: &str) -> Result<()> {
+        tracing::info!(external_id, "Terminating DigitalOcean droplet");
+
+        let resp = self
+            .request_builder(
+                reqwest::Method::DELETE,
+                &format!("/v2/droplets/{}", external_id),
+            )
+            .send()
+            .await
+            .with_context(|| format!("Failed to delete droplet {}", external_id))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            tracing::warn!(external_id, "Droplet not found, assuming already deleted");
+            return Ok(());
+        }
+        Self::handle_error(resp).await
+    }
+
+    async fn health_check(&self, external_id: &str) -> Result<HealthStatus> {
+        let droplet = match self.get_droplet(external_id.parse().context("Invalid droplet ID")?).await {
+            Ok(Some(d)) => d,
+            Ok(None) => {
+                return Ok(HealthStatus::Unhealthy {
+                    reason: "Droplet not found".to_string(),
+                });
+            }
+            Err(e) => {
+                return Ok(HealthStatus::Unhealthy {
+                    reason: format!("Failed to check droplet: {:#}", e),
+                });
+            }
+        };
+
+        match droplet.status.as_str() {
+            "active" => {
+                let uptime_seconds = chrono::DateTime::parse_from_rfc3339(&droplet.created_at)
+                    .map(|dt| {
+                        dt.signed_duration_since(chrono::Utc::now())
+                            .num_seconds()
+                            .unsigned_abs()
+                    })
+                    .unwrap_or(0);
+                Ok(HealthStatus::Healthy { uptime_seconds })
+            }
+            "new" => Ok(HealthStatus::Unhealthy {
+                reason: "Droplet is still being created".to_string(),
+            }),
+            "off" => Ok(HealthStatus::Unhealthy {
+                reason: "Droplet is powered off".to_string(),
+            }),
+            "archive" => Ok(HealthStatus::Unhealthy {
+                reason: "Droplet is archived".to_string(),
+            }),
+            other => Ok(HealthStatus::Unhealthy {
+                reason: format!("Unknown droplet status: {}", other),
+            }),
+        }
+    }
+
+    async fn get_instance(&self, external_id: &str) -> Result<Option<Instance>> {
+        let droplet_id: i64 = external_id.parse().context("Invalid droplet ID")?;
+        match self.get_droplet(droplet_id).await? {
+            Some(droplet) => Ok(Some(self.droplet_to_instance(&droplet))),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_running_instances(&self) -> Result<Vec<RunningInstance>> {
+        let mut all_instances = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            let resp = self
+                .request_builder(
+                    reqwest::Method::GET,
+                    &format!("/v2/droplets?tag_name={}&page={}&per_page=200", DC_AGENT_TAG, page),
+                )
+                .send()
+                .await
+                .context("Failed to list droplets")?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                bail!("Failed to list droplets: status={}, body={}", status, body);
+            }
+
+            let droplets_resp: DropletsResponse = resp
+                .json()
+                .await
+                .context("Failed to parse droplets list response")?;
+
+            for droplet in &droplets_resp.droplets {
+                let contract_id = extract_contract_id(&droplet.name);
+                all_instances.push(RunningInstance {
+                    external_id: droplet.id.to_string(),
+                    contract_id,
+                });
+            }
+
+            let total = droplets_resp.meta.as_ref().map(|m| m.total).unwrap_or(0);
+            if (page * 200) as i64 >= total {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(all_instances)
+    }
+
+    async fn verify_setup(&self) -> SetupVerification {
+        let mut result = SetupVerification::default();
+
+        match self
+            .request_builder(reqwest::Method::GET, "/v2/droplets?per_page=1")
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                result.api_reachable = Some(true);
+            }
+            Ok(resp) => {
+                result.api_reachable = Some(false);
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                result.errors.push(format!(
+                    "DigitalOcean API returned error: status={}, body={}",
+                    status, body
+                ));
+                return result;
+            }
+            Err(e) => {
+                result.api_reachable = Some(false);
+                result
+                    .errors
+                    .push(format!("Cannot reach DigitalOcean API: {:#}", e));
+                return result;
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+#[path = "digitalocean_tests.rs"]
+mod tests;

--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -1,6 +1,7 @@
 use super::{
     HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance, SetupVerification,
 };
+use crate::api_client::ResourceInventory;
 use crate::config::DigitalOceanConfig;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -217,6 +218,8 @@ fn extract_contract_id(name: &str) -> Option<String> {
 pub struct DigitalOceanProvisioner {
     config: DigitalOceanConfig,
     client: Client,
+    base_url: String,
+    poll_interval: Duration,
 }
 
 impl DigitalOceanProvisioner {
@@ -225,11 +228,16 @@ impl DigitalOceanProvisioner {
             .timeout(Duration::from_secs(30))
             .build()
             .context("Failed to build HTTP client for DigitalOcean API")?;
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            base_url: DO_API_BASE.to_string(),
+            poll_interval: Duration::from_secs(5),
+        })
     }
 
     fn request_builder(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
-        let url = format!("{}{}", DO_API_BASE, path);
+        let url = format!("{}{}", self.base_url, path);
         self.client
             .request(method, &url)
             .bearer_auth(&self.config.api_token)
@@ -290,7 +298,7 @@ impl DigitalOceanProvisioner {
                 attempt,
                 "Waiting for droplet to become active"
             );
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(self.poll_interval).await;
         }
         bail!(
             "Droplet {} did not reach 'active' state within {} retries",
@@ -395,6 +403,62 @@ impl DigitalOceanProvisioner {
             gateway_ssh_port: None,
             gateway_port_range_start: None,
             gateway_port_range_end: None,
+        }
+    }
+
+    async fn fetch_account(&self) -> Result<AccountInfo> {
+        let resp = self
+            .request_builder(reqwest::Method::GET, "/v2/account")
+            .send()
+            .await
+            .context("Failed to get DO account info")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to get account info: status={}, body={}", status, body);
+        }
+
+        let account_resp: AccountResponse = resp
+            .json()
+            .await
+            .context("Failed to parse account response")?;
+        Ok(account_resp.account)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountResponse {
+    account: AccountInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountInfo {
+    droplet_limit: i64,
+    #[serde(default)]
+    email: String,
+    #[serde(default)]
+    status: String,
+}
+
+#[cfg(test)]
+impl DigitalOceanProvisioner {
+    fn new_for_mockito(url: String) -> Self {
+        let config = DigitalOceanConfig {
+            api_token: "test-token".to_string(),
+            default_size: "s-1vcpu-1gb".to_string(),
+            default_region: "nyc3".to_string(),
+            default_image: "ubuntu-24-04-x64".to_string(),
+        };
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("Failed to build test HTTP client");
+        Self {
+            config,
+            client,
+            base_url: url,
+            poll_interval: Duration::from_millis(10),
         }
     }
 }
@@ -644,7 +708,63 @@ impl Provisioner for DigitalOceanProvisioner {
             }
         }
 
+        match self
+            .request_builder(
+                reqwest::Method::GET,
+                &format!("/v2/images?slug={}", self.config.default_image),
+            )
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                let images_resp: ImagesResponse = resp.json().await.unwrap_or(ImagesResponse { images: vec![] });
+                if images_resp.images.is_empty() {
+                    result.template_exists = Some(false);
+                    result.errors.push(format!(
+                        "Default image '{}' not found on DigitalOcean",
+                        self.config.default_image
+                    ));
+                } else {
+                    result.template_exists = Some(true);
+                }
+            }
+            _ => {
+                result.warnings.push(
+                    "Could not verify default image existence".to_string(),
+                );
+            }
+        }
+
         result
+    }
+
+    async fn collect_resources(&self) -> Option<ResourceInventory> {
+        let account = match self.fetch_account().await {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to fetch DO account info for collect_resources");
+                return None;
+            }
+        };
+
+        tracing::info!(
+            droplet_limit = account.droplet_limit,
+            email = %account.email,
+            status = %account.status,
+            "DigitalOcean account info collected"
+        );
+
+        Some(ResourceInventory {
+            cpu_model: Some("DigitalOcean Droplet".to_string()),
+            cpu_cores: 0,
+            cpu_threads: 0,
+            cpu_mhz: None,
+            memory_total_mb: 0,
+            memory_available_mb: 0,
+            storage_pools: vec![],
+            gpu_devices: vec![],
+            templates: vec![],
+        })
     }
 }
 

--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tracing;
 
-const DO_API_BASE: &str = "https://api.digitalocean.com/v2";
+const DO_API_BASE: &str = "https://api.digitalocean.com";
 const DC_AGENT_TAG: &str = "dc-agent";
 
 // ── DO API response types ───────────────────────────────────────────────────
@@ -523,7 +523,9 @@ impl Provisioner for DigitalOceanProvisioner {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
             if let Some(key_id) = created_ssh_key_id {
-                let _ = self.delete_ssh_key(key_id).await;
+                if let Err(e) = self.delete_ssh_key(key_id).await {
+                    tracing::warn!(key_id, error = %e, "Failed to clean up SSH key after droplet creation failure");
+                }
             }
             bail!(
                 "Failed to create droplet: status={}, body={}",
@@ -552,15 +554,20 @@ impl Provisioner for DigitalOceanProvisioner {
             }
             Err(e) => {
                 tracing::error!(droplet_id, error = %e, "Droplet failed to become active, cleaning up");
-                let _ = self
+                if let Err(cleanup_err) = self
                     .request_builder(
                         reqwest::Method::DELETE,
                         &format!("/v2/droplets/{}", droplet_id),
                     )
                     .send()
-                    .await;
+                    .await
+                {
+                    tracing::warn!(droplet_id, error = %cleanup_err, "Failed to delete droplet during cleanup");
+                }
                 if let Some(key_id) = created_ssh_key_id {
-                    let _ = self.delete_ssh_key(key_id).await;
+                    if let Err(key_err) = self.delete_ssh_key(key_id).await {
+                        tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
+                    }
                 }
                 Err(e)
             }
@@ -595,9 +602,7 @@ impl Provisioner for DigitalOceanProvisioner {
                 });
             }
             Err(e) => {
-                return Ok(HealthStatus::Unhealthy {
-                    reason: format!("Failed to check droplet: {:#}", e),
-                });
+                return Err(e).context("Health check failed");
             }
         };
 
@@ -717,15 +722,24 @@ impl Provisioner for DigitalOceanProvisioner {
             .await
         {
             Ok(resp) if resp.status().is_success() => {
-                let images_resp: ImagesResponse = resp.json().await.unwrap_or(ImagesResponse { images: vec![] });
-                if images_resp.images.is_empty() {
-                    result.template_exists = Some(false);
-                    result.errors.push(format!(
-                        "Default image '{}' not found on DigitalOcean",
-                        self.config.default_image
-                    ));
-                } else {
-                    result.template_exists = Some(true);
+                match resp.json::<ImagesResponse>().await {
+                    Ok(images_resp) => {
+                        if images_resp.images.is_empty() {
+                            result.template_exists = Some(false);
+                            result.errors.push(format!(
+                                "Default image '{}' not found on DigitalOcean",
+                                self.config.default_image
+                            ));
+                        } else {
+                            result.template_exists = Some(true);
+                        }
+                    }
+                    Err(e) => {
+                        result.warnings.push(format!(
+                            "Failed to parse images response for '{}': {:#}",
+                            self.config.default_image, e
+                        ));
+                    }
                 }
             }
             _ => {
@@ -754,17 +768,7 @@ impl Provisioner for DigitalOceanProvisioner {
             "DigitalOcean account info collected"
         );
 
-        Some(ResourceInventory {
-            cpu_model: Some("DigitalOcean Droplet".to_string()),
-            cpu_cores: 0,
-            cpu_threads: 0,
-            cpu_mhz: None,
-            memory_total_mb: 0,
-            memory_available_mb: 0,
-            storage_pools: vec![],
-            gpu_devices: vec![],
-            templates: vec![],
-        })
+        None
     }
 }
 

--- a/dc-agent/src/provisioner/digitalocean_tests.rs
+++ b/dc-agent/src/provisioner/digitalocean_tests.rs
@@ -683,6 +683,22 @@ async fn test_health_check_droplet_off() {
 }
 
 #[tokio::test]
+async fn test_health_check_api_error_returns_err() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/12345")
+        .with_status(500)
+        .with_body(r#"{"id":"server_error","message":"Internal error"}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.health_check("12345").await;
+    assert!(result.is_err(), "health_check should return Err on API error, not Ok(Unhealthy)");
+}
+
+#[tokio::test]
 async fn test_get_instance() {
     let mut server = mockito::Server::new_async().await;
 
@@ -817,7 +833,33 @@ async fn test_verify_setup_image_not_found() {
 }
 
 #[tokio::test]
-async fn test_collect_resources_success() {
+async fn test_verify_setup_image_json_parse_failure() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _droplets = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/droplets\?.*per_page=1.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"droplets":[],"meta":{"total":0}}"#)
+        .create_async()
+        .await;
+
+    let _images = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/images\?.*slug=ubuntu-24-04-x64.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"this is not valid json"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.api_reachable, Some(true));
+    assert!(!result.warnings.is_empty(), "Should have warning about JSON parse failure");
+}
+
+#[tokio::test]
+async fn test_collect_resources_success_returns_none() {
     let mut server = mockito::Server::new_async().await;
 
     let _mock = server
@@ -830,9 +872,7 @@ async fn test_collect_resources_success() {
 
     let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
     let result = prov.collect_resources().await;
-    assert!(result.is_some(), "collect_resources should return Some");
-    let inventory = result.unwrap();
-    assert_eq!(inventory.cpu_model, Some("DigitalOcean Droplet".to_string()));
+    assert!(result.is_none(), "collect_resources should return None (no host resource data available for cloud provider)");
 }
 
 #[tokio::test]

--- a/dc-agent/src/provisioner/digitalocean_tests.rs
+++ b/dc-agent/src/provisioner/digitalocean_tests.rs
@@ -1,7 +1,46 @@
 use super::*;
 
+fn make_provision_request() -> ProvisionRequest {
+    ProvisionRequest {
+        contract_id: "test-contract-123".to_string(),
+        offering_id: "offering-1".to_string(),
+        cpu_cores: Some(1),
+        memory_mb: Some(1024),
+        storage_gb: None,
+        requester_ssh_pubkey: None,
+        instance_config: None,
+        post_provision_script: None,
+    }
+}
+
+fn make_provision_request_with_ssh() -> ProvisionRequest {
+    ProvisionRequest {
+        contract_id: "test-contract-456".to_string(),
+        offering_id: "offering-1".to_string(),
+        cpu_cores: Some(1),
+        memory_mb: Some(1024),
+        storage_gb: None,
+        requester_ssh_pubkey: Some("ssh-ed25519 AAAATEST".to_string()),
+        instance_config: None,
+        post_provision_script: None,
+    }
+}
+
+fn active_droplet_json(id: i64, name: &str) -> String {
+    format!(
+        r#"{{"id":{},"name":"{}","status":"active","memory":1024,"vcpus":1,"disk":25,"locked":false,"created_at":"2020-07-21T18:37:44Z","networks":{{"v4":[{{"ip_address":"192.241.165.154","netmask":"255.255.255.0","gateway":"192.241.165.1","type":"public"}}],"v6":[]}},"region":{{"name":"New York 3","slug":"nyc3"}},"size_slug":"s-1vcpu-1gb","tags":["dc-agent"],"features":[]}}"#,
+        id, name
+    )
+}
+
+fn new_droplet_json(id: i64, name: &str) -> String {
+    format!(
+        r#"{{"id":{},"name":"{}","status":"new","memory":1024,"vcpus":1,"disk":25,"locked":false,"created_at":"2020-07-21T18:37:44Z","networks":{{"v4":[],"v6":[]}},"region":{{"name":"New York 3","slug":"nyc3"}},"size_slug":"s-1vcpu-1gb","tags":["dc-agent"],"features":[]}}"#,
+        id, name
+    )
+}
+
 // ── DO API response deserialization tests ────────────────────────────────────
-// These validate the response types against known DigitalOcean API v2 JSON.
 
 #[test]
 fn test_deserialize_droplets_response() {
@@ -339,6 +378,476 @@ fn test_droplet_to_instance_mapping() {
     assert_eq!(details["size_slug"], "s-2vcpu-2gb");
     assert_eq!(details["region"], "ams3");
     assert_eq!(details["vcpus"], 2);
+}
+
+#[test]
+fn test_resolve_size_from_instance_config() {
+    let config = DigitalOceanConfig {
+        api_token: "test-token".to_string(),
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+    let mut request = make_provision_request();
+    request.instance_config = Some(serde_json::json!({"size": "s-2vcpu-4gb"}));
+    assert_eq!(provisioner.resolve_size(&request), "s-2vcpu-4gb");
+}
+
+#[test]
+fn test_resolve_size_default() {
+    let config = DigitalOceanConfig {
+        api_token: "test-token".to_string(),
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+    assert_eq!(provisioner.resolve_size(&make_provision_request()), "s-1vcpu-1gb");
+}
+
+#[test]
+fn test_resolve_region_from_instance_config() {
+    let config = DigitalOceanConfig {
+        api_token: "test-token".to_string(),
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+    let mut request = make_provision_request();
+    request.instance_config = Some(serde_json::json!({"region": "ams3"}));
+    assert_eq!(provisioner.resolve_region(&request), "ams3");
+}
+
+#[test]
+fn test_resolve_image_from_instance_config() {
+    let config = DigitalOceanConfig {
+        api_token: "test-token".to_string(),
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+    let mut request = make_provision_request();
+    request.instance_config = Some(serde_json::json!({"image": "debian-12-x64"}));
+    assert_eq!(provisioner.resolve_image(&request), "debian-12-x64");
+}
+
+// ── Mockito-based HTTP tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_provision_creates_droplet() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(98765, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let _get_active = server
+        .mock("GET", "/v2/droplets/98765")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_json(98765, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request()).await;
+    assert!(result.is_ok(), "provision should succeed: {:?}", result.err());
+
+    let instance = result.unwrap();
+    assert_eq!(instance.external_id, "98765");
+    assert_eq!(instance.ip_address.as_deref(), Some("192.241.165.154"));
+}
+
+#[tokio::test]
+async fn test_provision_with_ssh_key() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _ssh_key = server
+        .mock("POST", "/v2/account/keys")
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"ssh_key":{"id":42,"name":"dc-test-contract-456","fingerprint":"aa:bb"}}"#)
+        .create_async()
+        .await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(55555, "dc-test-contract-456")
+        ))
+        .create_async()
+        .await;
+
+    let _get_active = server
+        .mock("GET", "/v2/droplets/55555")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_json(55555, "dc-test-contract-456")
+        ))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request_with_ssh()).await;
+    assert!(result.is_ok(), "provision with SSH key should succeed: {:?}", result.err());
+
+    let instance = result.unwrap();
+    assert_eq!(instance.external_id, "55555");
+}
+
+#[tokio::test]
+async fn test_provision_api_error_returns_err() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(422)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"unprocessable_entity","message":"Invalid region"}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request()).await;
+    assert!(result.is_err(), "provision should fail on API error");
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(err.contains("422"), "Error should mention status 422: {}", err);
+}
+
+#[tokio::test]
+async fn test_provision_droplet_never_becomes_active() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(11111, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let _get_new = server
+        .mock("GET", "/v2/droplets/11111")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(11111, "dc-test-contract-123")
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let _delete = server
+        .mock("DELETE", mockito::Matcher::Any)
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request()).await;
+    assert!(result.is_err(), "provision should fail when droplet never becomes active");
+}
+
+#[tokio::test]
+async fn test_terminate_droplet() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("DELETE", "/v2/droplets/12345")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.terminate("12345").await;
+    assert!(result.is_ok(), "terminate should succeed");
+}
+
+#[tokio::test]
+async fn test_terminate_not_found_returns_ok() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("DELETE", "/v2/droplets/99999")
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.terminate("99999").await;
+    assert!(result.is_ok(), "terminate should return Ok for 404");
+}
+
+#[tokio::test]
+async fn test_terminate_api_error_returns_err() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("DELETE", "/v2/droplets/12345")
+        .with_status(500)
+        .with_body(r#"{"id":"server_error","message":"Internal error"}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.terminate("12345").await;
+    assert!(result.is_err(), "terminate should fail on 500");
+}
+
+#[tokio::test]
+async fn test_health_check_active() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/12345")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_json(12345, "dc-test")
+        ))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.health_check("12345").await.unwrap();
+    match result {
+        HealthStatus::Healthy { uptime_seconds } => {
+            assert!(uptime_seconds > 0, "uptime should be positive");
+        }
+        _ => panic!("Expected Healthy, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn test_health_check_not_found() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/99999")
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.health_check("99999").await.unwrap();
+    assert!(
+        matches!(result, HealthStatus::Unhealthy { .. }),
+        "Expected Unhealthy for 404"
+    );
+}
+
+#[tokio::test]
+async fn test_health_check_droplet_off() {
+    let mut server = mockito::Server::new_async().await;
+
+    let droplet_json = r#"{"id":12345,"name":"test","status":"off","memory":1024,"vcpus":1,"disk":25,"locked":false,"created_at":"2020-07-21T18:37:44Z","networks":{"v4":[],"v6":[]},"region":{"name":"NY3","slug":"nyc3"},"size_slug":"s-1vcpu-1gb","tags":[],"features":[]}"#;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/12345")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"droplet":{}}}"#, droplet_json))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.health_check("12345").await.unwrap();
+    if let HealthStatus::Unhealthy { reason } = &result {
+        assert!(reason.contains("powered off"), "Expected 'powered off', got: {}", reason);
+    } else {
+        panic!("Expected Unhealthy for 'off' status, got {:?}", result);
+    }
+}
+
+#[tokio::test]
+async fn test_get_instance() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/12345")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_json(12345, "dc-test")
+        ))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.get_instance("12345").await.unwrap();
+    let instance = result.expect("Should find instance");
+    assert_eq!(instance.external_id, "12345");
+    assert_eq!(instance.ip_address.as_deref(), Some("192.241.165.154"));
+}
+
+#[tokio::test]
+async fn test_get_instance_not_found() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/droplets/99999")
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.get_instance("99999").await.unwrap();
+    assert!(result.is_none(), "Should return None for 404");
+}
+
+#[tokio::test]
+async fn test_list_running_instances() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/droplets\?.*tag_name=dc-agent.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplets":[{},{}],"meta":{{"total":2}}}}"#,
+            active_droplet_json(100, "dc-contract-a"),
+            active_droplet_json(200, "dc-contract-b"),
+        ))
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let instances = prov.list_running_instances().await.unwrap();
+    assert_eq!(instances.len(), 2);
+    assert_eq!(instances[0].external_id, "100");
+    assert_eq!(instances[0].contract_id, Some("contract-a".to_string()));
+    assert_eq!(instances[1].external_id, "200");
+    assert_eq!(instances[1].contract_id, Some("contract-b".to_string()));
+}
+
+#[tokio::test]
+async fn test_verify_setup_success() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _droplets = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/droplets\?.*per_page=1.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"droplets":[],"meta":{"total":0}}"#)
+        .create_async()
+        .await;
+
+    let _images = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/images\?.*slug=ubuntu-24-04-x64.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"images":[{"id":1,"name":"Ubuntu 24.04","slug":"ubuntu-24-04-x64","distribution":"Ubuntu","public":true,"available":true}]}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.api_reachable, Some(true));
+    assert_eq!(result.template_exists, Some(true));
+    assert!(result.errors.is_empty(), "Expected no errors, got: {:?}", result.errors);
+}
+
+#[tokio::test]
+async fn test_verify_setup_api_unreachable() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/droplets\?.*".to_string()))
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"unauthorized","message":"Invalid API token"}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.api_reachable, Some(false));
+    assert!(!result.errors.is_empty());
+}
+
+#[tokio::test]
+async fn test_verify_setup_image_not_found() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _droplets = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/droplets\?.*per_page=1.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"droplets":[],"meta":{"total":0}}"#)
+        .create_async()
+        .await;
+
+    let _images = server
+        .mock("GET", mockito::Matcher::Regex(r"/v2/images\?.*slug=ubuntu-24-04-x64.*".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"images":[]}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.verify_setup().await;
+    assert_eq!(result.api_reachable, Some(true));
+    assert_eq!(result.template_exists, Some(false));
+    assert!(!result.errors.is_empty(), "Should have error about missing image");
+}
+
+#[tokio::test]
+async fn test_collect_resources_success() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/account")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"account":{"droplet_limit":25,"email":"test@example.com","status":"active"}}"#)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.collect_resources().await;
+    assert!(result.is_some(), "collect_resources should return Some");
+    let inventory = result.unwrap();
+    assert_eq!(inventory.cpu_model, Some("DigitalOcean Droplet".to_string()));
+}
+
+#[tokio::test]
+async fn test_collect_resources_api_failure_returns_none() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock = server
+        .mock("GET", "/v2/account")
+        .with_status(500)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.collect_resources().await;
+    assert!(result.is_none(), "collect_resources should return None on API failure");
 }
 
 // ── Integration test (requires DIGITALOCEAN_API_TOKEN env var) ──────────────

--- a/dc-agent/src/provisioner/digitalocean_tests.rs
+++ b/dc-agent/src/provisioner/digitalocean_tests.rs
@@ -1,0 +1,428 @@
+use super::*;
+
+// ── DO API response deserialization tests ────────────────────────────────────
+// These validate the response types against known DigitalOcean API v2 JSON.
+
+#[test]
+fn test_deserialize_droplets_response() {
+    let json = r#"{
+        "droplets": [
+            {
+                "id": 3164444,
+                "name": "example.com",
+                "status": "active",
+                "memory": 1024,
+                "vcpus": 1,
+                "disk": 25,
+                "locked": false,
+                "created_at": "2020-07-21T18:37:44Z",
+                "networks": {
+                    "v4": [
+                        {"ip_address": "10.128.192.124", "netmask": "255.255.0.0", "gateway": "", "type": "private"},
+                        {"ip_address": "192.241.165.154", "netmask": "255.255.255.0", "gateway": "192.241.165.1", "type": "public"}
+                    ],
+                    "v6": [
+                        {"ip_address": "2604:a880:0:1010::18a:a001", "netmask": 64, "gateway": "2604:a880:0:1010::1", "type": "public"}
+                    ]
+                },
+                "region": {"name": "New York 3", "slug": "nyc3"},
+                "size_slug": "s-1vcpu-1gb",
+                "tags": ["web", "env:prod"],
+                "image": {
+                    "id": 63663980,
+                    "name": "20.04 (LTS) x64",
+                    "slug": "ubuntu-20-04-x64",
+                    "distribution": "Ubuntu"
+                },
+                "features": ["backups", "private_networking", "ipv6"],
+                "backup_ids": [],
+                "snapshot_ids": [],
+                "volume_ids": []
+            }
+        ],
+        "meta": {"total": 1}
+    }"#;
+
+    let resp: DropletsResponse = serde_json::from_str(json).expect("Failed to deserialize droplets");
+    assert_eq!(resp.droplets.len(), 1);
+
+    let droplet = &resp.droplets[0];
+    assert_eq!(droplet.id, 3164444);
+    assert_eq!(droplet.name, "example.com");
+    assert_eq!(droplet.status, "active");
+    assert_eq!(droplet.memory, 1024);
+    assert_eq!(droplet.vcpus, 1);
+    assert_eq!(droplet.disk, 25);
+    assert_eq!(droplet.region.slug, "nyc3");
+    assert_eq!(droplet.size_slug, "s-1vcpu-1gb");
+    assert_eq!(droplet.tags, vec!["web", "env:prod"]);
+
+    assert_eq!(
+        droplet.public_ipv4().as_deref(),
+        Some("192.241.165.154")
+    );
+    assert_eq!(
+        droplet.public_ipv6().as_deref(),
+        Some("2604:a880:0:1010::18a:a001")
+    );
+
+    let meta = resp.meta.as_ref().expect("meta should be present");
+    assert_eq!(meta.total, 1);
+}
+
+#[test]
+fn test_deserialize_create_droplet_response() {
+    let json = r#"{
+        "droplet": {
+            "id": 12345678,
+            "name": "dc-test-contract",
+            "status": "new",
+            "memory": 1024,
+            "vcpus": 1,
+            "disk": 25,
+            "locked": false,
+            "created_at": "2020-07-21T18:37:44Z",
+            "networks": {"v4": [], "v6": []},
+            "region": {"name": "New York 3", "slug": "nyc3"},
+            "size_slug": "s-1vcpu-1gb",
+            "tags": ["dc-agent"],
+            "features": [],
+            "backup_ids": [],
+            "snapshot_ids": [],
+            "volume_ids": []
+        },
+        "links": {"actions": [{"id": 999, "rel": "create", "href": "https://api.digitalocean.com/v2/actions/999"}]}
+    }"#;
+
+    let resp: DropletResponse = serde_json::from_str(json).expect("Failed to deserialize droplet");
+    assert_eq!(resp.droplet.id, 12345678);
+    assert_eq!(resp.droplet.status, "new");
+    assert!(resp.droplet.public_ipv4().is_none());
+}
+
+#[test]
+fn test_deserialize_sizes_response() {
+    let json = r#"{
+        "sizes": [
+            {
+                "slug": "s-1vcpu-1gb",
+                "memory": 1024,
+                "vcpus": 1,
+                "disk": 25,
+                "price_monthly": 5.0,
+                "price_hourly": 0.00744,
+                "available": true,
+                "regions": ["nyc3", "ams3", "sfo3"]
+            },
+            {
+                "slug": "s-2vcpu-4gb",
+                "memory": 4096,
+                "vcpus": 2,
+                "disk": 80,
+                "price_monthly": 20.0,
+                "price_hourly": 0.02976,
+                "available": true,
+                "regions": ["nyc3", "ams3", "sfo3"]
+            }
+        ],
+        "meta": {"total": 2}
+    }"#;
+
+    let resp: SizesResponse = serde_json::from_str(json).expect("Failed to deserialize sizes");
+    assert_eq!(resp.sizes.len(), 2);
+    assert_eq!(resp.sizes[0].slug, "s-1vcpu-1gb");
+    assert_eq!(resp.sizes[1].vcpus, 2);
+}
+
+#[test]
+fn test_deserialize_regions_response() {
+    let json = r#"{
+        "regions": [
+            {"name": "New York 3", "slug": "nyc3", "available": true},
+            {"name": "Amsterdam 3", "slug": "ams3", "available": true}
+        ],
+        "meta": {"total": 2}
+    }"#;
+
+    let resp: RegionsResponse = serde_json::from_str(json).expect("Failed to deserialize regions");
+    assert_eq!(resp.regions.len(), 2);
+    assert_eq!(resp.regions[0].slug, "nyc3");
+}
+
+#[test]
+fn test_deserialize_images_response() {
+    let json = r#"{
+        "images": [
+            {
+                "id": 63663980,
+                "name": "20.04 (LTS) x64",
+                "slug": "ubuntu-20-04-x64",
+                "distribution": "Ubuntu",
+                "public": true,
+                "available": true
+            },
+            {
+                "id": 12345,
+                "name": "My Custom Image",
+                "slug": null,
+                "distribution": "Ubuntu",
+                "public": false,
+                "available": true
+            }
+        ],
+        "meta": {"total": 2}
+    }"#;
+
+    let resp: ImagesResponse = serde_json::from_str(json).expect("Failed to deserialize images");
+    assert_eq!(resp.images.len(), 2);
+    assert_eq!(resp.images[0].slug, Some("ubuntu-20-04-x64".to_string()));
+    assert_eq!(resp.images[1].slug, None);
+}
+
+#[test]
+fn test_deserialize_ssh_key_response() {
+    let json = r#"{
+        "ssh_key": {
+            "id": 512189,
+            "name": "dc-test-contract",
+            "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a1:09:41:3b:3e:5e"
+        }
+    }"#;
+
+    let resp: SshKeyResponse = serde_json::from_str(json).expect("Failed to deserialize SSH key");
+    assert_eq!(resp.ssh_key.id, 512189);
+    assert_eq!(resp.ssh_key.name, "dc-test-contract");
+}
+
+#[test]
+fn test_deserialize_action_response() {
+    let json = r#"{
+        "action": {
+            "id": 36804636,
+            "status": "in-progress",
+            "type": "create"
+        }
+    }"#;
+
+    let resp: DoActionResponse = serde_json::from_str(json).expect("Failed to deserialize action");
+    assert_eq!(resp.action.id, 36804636);
+    assert_eq!(resp.action.status, "in-progress");
+    assert_eq!(resp.action.action_type, "create");
+}
+
+#[test]
+fn test_droplet_name_format() {
+    assert_eq!(droplet_name("abc123"), "dc-abc123");
+    assert_eq!(droplet_name("test-contract-456"), "dc-test-contract-456");
+}
+
+#[test]
+fn test_extract_contract_id() {
+    assert_eq!(extract_contract_id("dc-abc123"), Some("abc123".to_string()));
+    assert_eq!(extract_contract_id("dc-test-contract"), Some("test-contract".to_string()));
+    assert_eq!(extract_contract_id("other-name"), None);
+}
+
+#[test]
+fn test_droplet_network_extraction_no_networks() {
+    let droplet = Droplet {
+        id: 1,
+        name: "test".to_string(),
+        status: "active".to_string(),
+        memory: 1024,
+        vcpus: 1,
+        disk: 25,
+        locked: false,
+        created_at: "2020-07-21T18:37:44Z".to_string(),
+        networks: Networks::default(),
+        region: DoRegion { name: "test".to_string(), slug: "nyc3".to_string() },
+        size_slug: "s-1vcpu-1gb".to_string(),
+        tags: vec![],
+        image: None,
+        features: vec![],
+    };
+    assert!(droplet.public_ipv4().is_none());
+    assert!(droplet.public_ipv6().is_none());
+}
+
+#[test]
+fn test_droplet_multiple_v4_picks_public() {
+    let droplet = Droplet {
+        id: 1,
+        name: "test".to_string(),
+        status: "active".to_string(),
+        memory: 1024,
+        vcpus: 1,
+        disk: 25,
+        locked: false,
+        created_at: "2020-07-21T18:37:44Z".to_string(),
+        networks: Networks {
+            v4: vec![
+                NetworkV4 {
+                    ip_address: "10.0.0.1".to_string(),
+                    netmask: "255.255.0.0".to_string(),
+                    gateway: "".to_string(),
+                    network_type: "private".to_string(),
+                },
+                NetworkV4 {
+                    ip_address: "203.0.113.1".to_string(),
+                    netmask: "255.255.255.0".to_string(),
+                    gateway: "203.0.113.1".to_string(),
+                    network_type: "public".to_string(),
+                },
+            ],
+            v6: vec![],
+        },
+        region: DoRegion { name: "test".to_string(), slug: "nyc3".to_string() },
+        size_slug: "s-1vcpu-1gb".to_string(),
+        tags: vec![],
+        image: None,
+        features: vec![],
+    };
+    assert_eq!(droplet.public_ipv4().as_deref(), Some("203.0.113.1"));
+}
+
+#[test]
+fn test_droplet_to_instance_mapping() {
+    let config = DigitalOceanConfig {
+        api_token: "test-token".to_string(),
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+
+    let droplet = Droplet {
+        id: 12345,
+        name: "dc-test-contract".to_string(),
+        status: "active".to_string(),
+        memory: 2048,
+        vcpus: 2,
+        disk: 50,
+        locked: false,
+        created_at: "2020-07-21T18:37:44Z".to_string(),
+        networks: Networks {
+            v4: vec![NetworkV4 {
+                ip_address: "203.0.113.50".to_string(),
+                netmask: "255.255.255.0".to_string(),
+                gateway: "203.0.113.1".to_string(),
+                network_type: "public".to_string(),
+            }],
+            v6: vec![NetworkV6 {
+                ip_address: "2604:a880:0:1010::18a:a001".to_string(),
+                netmask: 64,
+                gateway: "2604:a880:0:1010::1".to_string(),
+                network_type: "public".to_string(),
+            }],
+        },
+        region: DoRegion { name: "Amsterdam 3".to_string(), slug: "ams3".to_string() },
+        size_slug: "s-2vcpu-2gb".to_string(),
+        tags: vec!["dc-agent".to_string()],
+        image: Some(DoImage {
+            id: 63663980,
+            name: "20.04 (LTS) x64".to_string(),
+            slug: Some("ubuntu-20-04-x64".to_string()),
+            distribution: "Ubuntu".to_string(),
+        }),
+        features: vec![],
+    };
+
+    let instance = provisioner.droplet_to_instance(&droplet);
+    assert_eq!(instance.external_id, "12345");
+    assert_eq!(instance.ip_address.as_deref(), Some("203.0.113.50"));
+    assert_eq!(instance.public_ip.as_deref(), Some("203.0.113.50"));
+    assert_eq!(instance.ipv6_address.as_deref(), Some("2604:a880:0:1010::18a:a001"));
+    assert_eq!(instance.ssh_port, 22);
+    assert!(instance.root_password.is_none());
+
+    let details = instance.additional_details.unwrap();
+    assert_eq!(details["size_slug"], "s-2vcpu-2gb");
+    assert_eq!(details["region"], "ams3");
+    assert_eq!(details["vcpus"], 2);
+}
+
+// ── Integration test (requires DIGITALOCEAN_API_TOKEN env var) ──────────────
+// Run with: cargo nextest run -p dc-agent digitalocean --run-ignored ignored-only
+
+#[tokio::test]
+#[ignore]
+async fn integration_list_droplets() {
+    let token = std::env::var("DIGITALOCEAN_API_TOKEN")
+        .expect("DIGITALOCEAN_API_TOKEN env var required for integration test");
+
+    let config = DigitalOceanConfig {
+        api_token: token,
+        default_size: "s-1vcpu-1gb".to_string(),
+        default_region: "nyc3".to_string(),
+        default_image: "ubuntu-24-04-x64".to_string(),
+    };
+    let provisioner = DigitalOceanProvisioner::new(config).unwrap();
+
+    let verification = provisioner.verify_setup().await;
+    assert!(verification.api_reachable == Some(true), "API should be reachable: {:?}", verification.errors);
+
+    let instances = provisioner.list_running_instances().await.expect("list should succeed");
+    println!("Found {} running instances", instances.len());
+    for inst in &instances {
+        println!("  instance: external_id={}, contract_id={:?}", inst.external_id, inst.contract_id);
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn integration_catalog_endpoints() {
+    use reqwest::Client;
+
+    let token = std::env::var("DIGITALOCEAN_API_TOKEN")
+        .expect("DIGITALOCEAN_API_TOKEN env var required for integration test");
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    // GET /v2/regions
+    let resp = client
+        .get("https://api.digitalocean.com/v2/regions")
+        .bearer_auth(&token)
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .expect("regions request failed");
+    assert!(resp.status().is_success(), "regions: status={}", resp.status());
+    let regions: RegionsResponse = resp.json().await.expect("regions parse failed");
+    println!("Regions: {} available", regions.regions.iter().filter(|r| r.available).count());
+    for r in regions.regions.iter().take(5) {
+        println!("  {} ({}) available={}", r.slug, r.name, r.available);
+    }
+
+    // GET /v2/sizes
+    let resp = client
+        .get("https://api.digitalocean.com/v2/sizes")
+        .bearer_auth(&token)
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .expect("sizes request failed");
+    assert!(resp.status().is_success(), "sizes: status={}", resp.status());
+    let sizes: SizesResponse = resp.json().await.expect("sizes parse failed");
+    println!("Sizes: {} available", sizes.sizes.iter().filter(|s| s.available).count());
+    for s in sizes.sizes.iter().filter(|s| s.available).take(5) {
+        println!("  {} ({}MB, {}vCPU) ${}/mo", s.slug, s.memory, s.vcpus, s.price_monthly);
+    }
+
+    // GET /v2/images?type=distribution
+    let resp = client
+        .get("https://api.digitalocean.com/v2/images?type=distribution")
+        .bearer_auth(&token)
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .expect("images request failed");
+    assert!(resp.status().is_success(), "images: status={}", resp.status());
+    let images: ImagesResponse = resp.json().await.expect("images parse failed");
+    println!("Distribution images: {}", images.images.len());
+    for img in images.images.iter().take(5) {
+        println!("  {} ({}) slug={:?}", img.name, img.distribution, img.slug);
+    }
+}

--- a/dc-agent/src/provisioner/mod.rs
+++ b/dc-agent/src/provisioner/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+pub mod digitalocean;
 pub mod docker;
 pub mod manual;
 pub mod proxmox;


### PR DESCRIPTION
## Summary

Implements the DigitalOcean provisioner as a `Provisioner` trait impl in dc-agent, following the pattern established by DockerProvisioner.

**Changes on top of PoC (prep commit):**
- **Mockito-based HTTP tests**: 17 new mock tests covering provision, terminate, health_check, get_instance, list_running_instances, verify_setup, and collect_resources flows
- **Test injection**: Added configurable `base_url` and `poll_interval` fields with `new_for_mockito()` constructor for fast, deterministic test execution
- **`collect_resources()`**: Queries `/v2/account` for account-level info (droplet limit, email, status)
- **Enhanced `verify_setup()`**: Added default image existence check via `/v2/images?slug=...` (follows Docker pattern from #345)
- **Doctor `--test-provision`**: Added DigitalOcean match arm so `dc-agent doctor --test-provision` creates/destroys a real test droplet
- **Unit tests**: Added `resolve_size`, `resolve_region`, `resolve_image` tests for instance_config override logic

**Test plan:**
- `cargo test -p dc-agent digitalocean` — 34 DO tests (32 pass, 2 ignored integration)
- `cargo test -p dc-agent` — full suite 222 tests pass
- `cargo clippy -p dc-agent --tests` — no clippy errors

**Integration test** (requires `DIGITALOCEAN_API_TOKEN`):
```
cargo nextest run -p dc-agent digitalocean --run-ignored ignored-only
```

Closes #349
Parent: #122