### PR TITLE
feat(#254): add SSH key rotation completed indicator to rentals list

### DIFF
--- a/website/src/routes/dashboard/rentals/+page.svelte
+++ b/website/src/routes/dashboard/rentals/+page.svelte
@@ -49,6 +49,7 @@
 	let pendingGuidanceDismissed = $state(
 		typeof sessionStorage !== 'undefined' && sessionStorage.getItem('pending_guidance_dismissed') === '1'
 	);
+	let recentlyCompletedRotations = $state<Set<string>>(new Set());
 
 	const spendingStats = $derived({
 		total: contracts.length,
@@ -200,6 +201,14 @@
 						? { ...c, ssh_key_rotation_requested_at_ns: undefined }
 						: c
 				);
+				const updated = new Set(recentlyCompletedRotations);
+				updated.add(rotation.contract_id);
+				recentlyCompletedRotations = updated;
+				setTimeout(() => {
+					const next = new Set(recentlyCompletedRotations);
+					next.delete(rotation.contract_id);
+					recentlyCompletedRotations = next;
+				}, 30_000);
 			} catch (e) {
 				console.error('[Rentals] Failed to parse ssh_key_rotation_complete SSE event:', e);
 			}
@@ -688,6 +697,14 @@
 										Key rotation in progress
 									</span>
 								{/if}
+								{#if recentlyCompletedRotations.has(contract.contract_id)}
+									<span
+										class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30"
+										title="SSH key rotation completed successfully"
+									>
+										&#10003; Key rotated
+									</span>
+								{/if}
 								<!-- Cancel button for cancelable contracts -->
 								{#if isCancellable(contract.status) && cancellingContractId !== contract.contract_id}
 									<button
@@ -874,6 +891,11 @@
 									<div class="text-xs text-amber-400 flex items-center gap-1 mt-1.5">
 										<span class="animate-spin inline-block h-2.5 w-2.5 border-t-2 border-b-2 border-amber-400 rounded-full"></span>
 										Rotating…
+									</div>
+								{/if}
+								{#if recentlyCompletedRotations.has(contract.contract_id)}
+									<div class="text-xs text-emerald-400 flex items-center gap-1 mt-1.5">
+										&#10003; Rotation complete
 									</div>
 								{/if}
 							</div>


### PR DESCRIPTION
## Summary
Follow-up from #195 / PR #249. Adds a visual "completed" state to the SSH key rotation status indicator on the rentals list page.

**Problem:** PR #249 added SSE listeners and an amber "Key rotation in progress" spinner, but when rotation completed, the spinner silently disappeared with no visual feedback.

**Changes:**
- Track recently completed rotations in a reactive `Set<string>` state
- On `ssh_key_rotation_complete` SSE event, show a green "✓ Key rotated" badge in the header area for 30 seconds
- Show a green "✓ Rotation complete" label in the SSH Key info box for 30 seconds
- Both indicators auto-dismiss after 30 seconds

**Visual states now:**
1. **In progress** (amber spinner) — `ssh_key_rotation_requested_at_ns` is set
2. **Complete** (green checkmark) — shown for 30s after SSE `ssh_key_rotation_complete`
3. **Idle** — no indicator (default)

## Files changed
- `website/src/routes/dashboard/rentals/+page.svelte` — added `recentlyCompletedRotations` state, updated SSE handler, added green completed indicators

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] Full Vitest suite — 839/839 tests pass
- [ ] Manual: trigger SSH key rotation from contract detail page, navigate to rentals list, verify amber spinner shows during rotation, then green "Key rotated" badge appears on completion