### PR TITLE
fix(#253): add tracing::warn! on SSH key rotation events DB error

### DIFF
--- a/api/src/openapi/providers.rs
+++ b/api/src/openapi/providers.rs
@@ -246,22 +246,27 @@ pub async fn contract_status_events(
                 };
 
                 let mut next_rotation_ns = state.last_rotation_event_ns;
-                if let Ok(rotation_events) = state
+                match state
                     .db
                     .get_ssh_key_rotation_events_for_user(&state.pk, state.last_rotation_event_ns)
                     .await
                 {
-                    for ev in &rotation_events {
-                        let data = serde_json::json!({
-                            "contract_id": ev.contract_id,
-                            "created_at": ev.created_at,
-                            "actor": ev.actor,
-                            "details": ev.details,
-                        });
-                        events.push(Event::message(data.to_string()).event_type(&ev.event_type));
-                        if ev.created_at > next_rotation_ns {
-                            next_rotation_ns = ev.created_at;
+                    Ok(rotation_events) => {
+                        for ev in &rotation_events {
+                            let data = serde_json::json!({
+                                "contract_id": ev.contract_id,
+                                "created_at": ev.created_at,
+                                "actor": ev.actor,
+                                "details": ev.details,
+                            });
+                            events.push(Event::message(data.to_string()).event_type(&ev.event_type));
+                            if ev.created_at > next_rotation_ns {
+                                next_rotation_ns = ev.created_at;
+                            }
                         }
+                    }
+                    Err(e) => {
+                        tracing::warn!("SSE ssh-key-rotation-events DB error: {:#}", e);
                     }
                 }
 


### PR DESCRIPTION
## Summary

Follow-up from #195 / PR #249. The SSE `contract_status_events` handler silently swallowed DB errors when polling for SSH key rotation events — `if let Ok(...)` with no `Err` branch. On DB failure, no warning was logged and the SSE stream continued as if nothing happened, with `last_rotation_event_ns` never advancing.

**Fix:** Convert to `match` with `tracing::warn!` on the `Err` branch, consistent with the project's fail-fast-with-details rule.

### What changed
- `api/src/openapi/providers.rs`: SSE rotation event poll now logs `tracing::warn!("SSE ssh-key-rotation-events DB error: {:#}", e)` on DB errors instead of silently discarding them.

### Test plan
- All 3 existing SSE rotation event format tests pass (`test_ssh_key_rotation_sse_event_*`).
- `cargo clippy -p api --tests` clean.
- `cargo build -p api --tests` clean.
- Note: Full DB integration tests require PostgreSQL; the SSE handler change is a logging-only addition with no behavioral change affecting existing tests.

### Observability note
Uses `warn!` rather than `error!` (used by sibling SSE handlers for password-reset and contract-status) because rotation events are supplementary to the primary contract-status SSE stream — a transient DB hiccup for the supplementary query should not be treated as fatal. The stream can continue serving contract-status events while rotation event polling recovers.

### Out of scope
Found 7 additional `if let Ok(...) = db...` silent-swallow patterns in adjacent SSE/webhook handlers (providers.rs, contracts.rs, cloud.rs, webhooks.rs). These are unrelated to the rotation code path and should be addressed in follow-up tickets.