### PR TITLE
fix(#361): move seen_ids exclusion into SQL in fetch_candidate_offerings

### DIFF
--- a/api/src/database/offerings.rs
+++ b/api/src/database/offerings.rs
@@ -2473,7 +2473,7 @@ impl Database {
 
         let profile = build_preference_profile(&signals);
         let seen_ids = self.fetch_seen_offering_ids(user_pubkey).await?;
-        let candidates = self.fetch_candidate_offerings(&seen_ids, limit * 5).await?;
+        let candidates = self.fetch_candidate_offerings(&seen_ids, limit).await?;
 
         let mut scored: Vec<RecommendedOffering> = candidates
             .into_iter()
@@ -2531,7 +2531,8 @@ impl Database {
         seen_ids: &HashSet<i64>,
         limit: i64,
     ) -> Result<Vec<CandidateOffering>> {
-        let mut rows = sqlx::query_as::<_, CandidateOffering>(
+        let seen_list: Vec<i64> = seen_ids.iter().copied().collect();
+        let rows = sqlx::query_as::<_, CandidateOffering>(
             r#"SELECT o.id as offering_id, o.offer_name, lower(encode(o.pubkey, 'hex')) as pubkey,
                       o.product_type, o.monthly_price, o.currency,
                       o.datacenter_country, o.datacenter_city,
@@ -2542,14 +2543,15 @@ impl Database {
                WHERE LOWER(o.visibility) = 'public'
                  AND o.is_draft = false
                  AND o.stock_status != 'out_of_stock'
+                 AND NOT (o.id = ANY($1))
                ORDER BY p.reliability_score DESC NULLS LAST, o.monthly_price ASC
-               LIMIT $1"#,
+               LIMIT $2"#,
         )
+        .bind(&seen_list)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
 
-        rows.retain(|c| !seen_ids.contains(&c.offering_id));
         Ok(rows)
     }
 }

--- a/api/src/database/offerings/tests.rs
+++ b/api/src/database/offerings/tests.rs
@@ -4658,7 +4658,63 @@ async fn test_fetch_candidate_offerings_excludes_drafts_and_private() {
     );
 }
 
-// ── trending offerings tests ───────────────────────────────────────────────────
+#[tokio::test]
+async fn test_fetch_candidate_offerings_limit_applies_after_exclusion() {
+    let db = setup_test_db().await;
+    delete_example_data(&db).await;
+
+    let provider = vec![0xECu8; 32];
+    for i in 0..10u8 {
+        let country = if i < 5 { "US" } else { "DE" };
+        insert_test_offering(&db, 100 + i as i64, &provider, country, 100.0 + i as f64).await;
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for i in 0..8 {
+        seen.insert(test_id_to_db_id(100 + i));
+    }
+
+    let candidates = db
+        .fetch_candidate_offerings(&seen, 3)
+        .await
+        .expect("fetch_candidate_offerings failed");
+
+    assert_eq!(
+        candidates.len(),
+        2,
+        "with 10 offerings, 8 seen, should return the 2 unseen (not be drained to 0 by LIMIT-before-filter)"
+    );
+    for c in &candidates {
+        assert!(
+            !seen.contains(&c.offering_id),
+            "seen offering {} must not appear in candidates",
+            c.offering_id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fetch_candidate_offerings_empty_seen_ids() {
+    let db = setup_test_db().await;
+    delete_example_data(&db).await;
+
+    let provider = vec![0xEDu8; 32];
+    insert_test_offering(&db, 110, &provider, "US", 100.0).await;
+    insert_test_offering(&db, 111, &provider, "DE", 200.0).await;
+
+    let seen = std::collections::HashSet::new();
+    let candidates = db
+        .fetch_candidate_offerings(&seen, 50)
+        .await
+        .expect("fetch_candidate_offerings failed");
+
+    assert!(
+        candidates.len() >= 2,
+        "empty seen set should return all candidates, got {}",
+        candidates.len()
+    );
+}
+
 
 #[tokio::test]
 async fn test_get_trending_offerings_with_views_appears() {


### PR DESCRIPTION
## Summary

Fixes #361 (parent #338)

**Problem:** In `fetch_candidate_offerings`, the SQL `LIMIT` was applied *before* Rust-side `rows.retain()` filtering that excluded seen offering IDs. For active users with many viewed/saved offerings, this meant the candidate pool could be drained to zero — the DB returned N rows, but after filtering out seen ones, few or none remained.

**Changes:**
- `api/src/database/offerings.rs`: Moved `seen_ids` exclusion into the SQL query using `NOT (o.id = ANY($1))` with a `Vec<i64>` array parameter. `LIMIT` now applies after exclusion.
- Removed the `limit * 5` multiplier in `get_recommended_offerings` — it was a bandaid for the pre-filter bug and is no longer needed.
- Removed `rows.retain()` call since filtering is now done server-side.

**Tests added** (`api/src/database/offerings/tests.rs`):
- `test_fetch_candidate_offerings_limit_applies_after_exclusion` — creates 10 offerings, marks 8 as seen, requests `LIMIT 3`, verifies exactly the 2 unseen offerings are returned (not 0 as the old code would produce).
- `test_fetch_candidate_offerings_empty_seen_ids` — verifies empty seen set returns all candidates (edge case for `= ANY($1)` with empty array).

All existing recommendation tests continue to pass.

## Test plan
- [x] `cargo clippy -p api --tests` clean
- [x] All targeted database tests pass against real PostgreSQL (7/7)
- [ ] CI full suite