### PR TITLE
refactor(#374): extract shared extract_contract_id() into provisioner module

### DIFF
--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -1,5 +1,6 @@
 use super::{
-    HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance, SetupVerification,
+    extract_contract_id, HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance,
+    SetupVerification,
 };
 use crate::api_client::ResourceInventory;
 use crate::config::DigitalOceanConfig;
@@ -207,10 +208,6 @@ struct CreateDropletRequest {
 
 fn droplet_name(contract_id: &str) -> String {
     format!("dc-{}", contract_id)
-}
-
-fn extract_contract_id(name: &str) -> Option<String> {
-    name.strip_prefix("dc-").map(String::from)
 }
 
 // ── DigitalOceanProvisioner ─────────────────────────────────────────────────

--- a/dc-agent/src/provisioner/digitalocean_tests.rs
+++ b/dc-agent/src/provisioner/digitalocean_tests.rs
@@ -256,13 +256,6 @@ fn test_droplet_name_format() {
 }
 
 #[test]
-fn test_extract_contract_id() {
-    assert_eq!(extract_contract_id("dc-abc123"), Some("abc123".to_string()));
-    assert_eq!(extract_contract_id("dc-test-contract"), Some("test-contract".to_string()));
-    assert_eq!(extract_contract_id("other-name"), None);
-}
-
-#[test]
 fn test_droplet_network_extraction_no_networks() {
     let droplet = Droplet {
         id: 1,

--- a/dc-agent/src/provisioner/docker.rs
+++ b/dc-agent/src/provisioner/docker.rs
@@ -1,5 +1,6 @@
 use super::{
-    HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance, SetupVerification,
+    extract_contract_id, HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance,
+    SetupVerification,
 };
 use crate::config::DockerConfig;
 use anyhow::{bail, Context, Result};
@@ -97,10 +98,6 @@ fn is_docker_not_found(e: &bollard::errors::Error) -> bool {
             ..
         }
     )
-}
-
-fn extract_contract_id(name: &str) -> Option<String> {
-    name.strip_prefix("dc-").map(String::from)
 }
 
 pub struct DockerProvisioner {

--- a/dc-agent/src/provisioner/docker_tests.rs
+++ b/dc-agent/src/provisioner/docker_tests.rs
@@ -31,17 +31,6 @@ fn test_container_name_format() {
 }
 
 #[test]
-fn test_extract_contract_id() {
-    assert_eq!(extract_contract_id("dc-abc123"), Some("abc123".to_string()));
-    assert_eq!(
-        extract_contract_id("dc-contract-456"),
-        Some("contract-456".to_string())
-    );
-    assert_eq!(extract_contract_id("other-name"), None);
-    assert_eq!(extract_contract_id("dc-"), Some("".to_string()));
-}
-
-#[test]
 fn test_resolve_image_from_config() {
     let config = default_config();
     let prov = DockerProvisioner::new_for_test(config);

--- a/dc-agent/src/provisioner/mod.rs
+++ b/dc-agent/src/provisioner/mod.rs
@@ -9,6 +9,10 @@ pub mod manual;
 pub mod proxmox;
 pub mod script;
 
+pub fn extract_contract_id(name: &str) -> Option<String> {
+    name.strip_prefix("dc-").map(String::from)
+}
+
 /// Instance provisioned by the agent
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Instance {
@@ -177,7 +181,6 @@ mod tests {
 
     #[test]
     fn test_instance_deserialization_without_public_ip_field() {
-        // Backward compatibility: JSON without public_ip should deserialize with public_ip: None
         let json = r#"{
             "external_id": "vm-123",
             "ip_address": "10.0.0.100",
@@ -192,5 +195,24 @@ mod tests {
             instance.public_ip.is_none(),
             "public_ip should default to None when absent from JSON"
         );
+    }
+
+    #[test]
+    fn test_extract_contract_id() {
+        assert_eq!(extract_contract_id("dc-abc123"), Some("abc123".to_string()));
+        assert_eq!(
+            extract_contract_id("dc-test-contract"),
+            Some("test-contract".to_string())
+        );
+        assert_eq!(
+            extract_contract_id("dc-contract-456"),
+            Some("contract-456".to_string())
+        );
+        assert_eq!(
+            extract_contract_id("dc-test-contract-123"),
+            Some("test-contract-123".to_string())
+        );
+        assert_eq!(extract_contract_id("other-name"), None);
+        assert_eq!(extract_contract_id("dc-"), Some("".to_string()));
     }
 }

--- a/dc-agent/src/provisioner/proxmox.rs
+++ b/dc-agent/src/provisioner/proxmox.rs
@@ -1,5 +1,6 @@
 use super::{
-    HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance, SetupVerification,
+    extract_contract_id, HealthStatus, Instance, ProvisionRequest, Provisioner, RunningInstance,
+    SetupVerification,
 };
 use crate::config::ProxmoxConfig;
 use anyhow::{bail, Context, Result};
@@ -566,11 +567,6 @@ impl ProxmoxProvisioner {
     async fn list_vms(&self) -> Result<Vec<VmListEntry>> {
         let path = format!("/api2/json/nodes/{}/qemu", self.config.node);
         self.api_get(&path).await
-    }
-
-    /// Extract contract ID from VM name (dc-{contract_id} -> contract_id)
-    fn extract_contract_id(name: &str) -> Option<String> {
-        name.strip_prefix("dc-").map(String::from)
     }
 
     async fn get_vm_ip(&self, vmid: u32) -> Result<(Option<String>, Option<String>)> {
@@ -1178,7 +1174,7 @@ impl Provisioner for ProxmoxProvisioner {
                 _ => continue,
             };
 
-            let contract_id = Self::extract_contract_id(name);
+            let contract_id = extract_contract_id(name);
             instances.push(RunningInstance {
                 external_id: vm.vmid.to_string(),
                 contract_id,

--- a/dc-agent/src/provisioner/proxmox_tests.rs
+++ b/dc-agent/src/provisioner/proxmox_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::super::{HealthStatus, ProvisionRequest, Provisioner};
+    use super::super::{extract_contract_id, HealthStatus, ProvisionRequest, Provisioner};
     use crate::config::ProxmoxConfig;
     use crate::provisioner::proxmox::{fnv1a_hash, ProxmoxProvisioner};
     use mockito::Server;
@@ -803,20 +803,20 @@ mod tests {
     #[test]
     fn test_extract_contract_id_valid() {
         assert_eq!(
-            ProxmoxProvisioner::extract_contract_id("dc-test-contract-123"),
+            extract_contract_id("dc-test-contract-123"),
             Some("test-contract-123".to_string())
         );
     }
 
     #[test]
     fn test_extract_contract_id_no_prefix() {
-        assert_eq!(ProxmoxProvisioner::extract_contract_id("test-vm"), None);
+        assert_eq!(extract_contract_id("test-vm"), None);
     }
 
     #[test]
     fn test_extract_contract_id_empty_after_prefix() {
         assert_eq!(
-            ProxmoxProvisioner::extract_contract_id("dc-"),
+            extract_contract_id("dc-"),
             Some("".to_string())
         );
     }


### PR DESCRIPTION
## Summary

Extract duplicated `extract_contract_id()` from three provisioner backends (`proxmox.rs`, `docker.rs`, `digitalocean.rs`) into a single shared function in `provisioner/mod.rs`.

### Changes
- **`provisioner/mod.rs`**: Added `pub fn extract_contract_id()` with a consolidated test covering all edge cases from the three original tests
- **`digitalocean.rs`**: Removed local `extract_contract_id()`, added `use super::extract_contract_id`
- **`docker.rs`**: Removed local `extract_contract_id()`, added `use super::extract_contract_id`
- **`proxmox.rs`**: Removed inherent method `extract_contract_id()`, added `use super::extract_contract_id`, updated call site from `Self::extract_contract_id()` to `extract_contract_id()`
- **`*_tests.rs`**: Removed 3 duplicate test functions; updated proxmox tests to call free function instead of `ProxmoxProvisioner::extract_contract_id()`

### Test plan
- [x] `cargo clippy -p dc-agent --tests` passes (no new warnings)
- [x] `cargo test -p dc-agent` — 223 tests pass (208 lib + 15 bin), 3 ignored (pre-existing integration tests)
- [x] Consolidated `test_extract_contract_id` covers all cases: valid prefix, multi-segment ID, no prefix, empty after prefix

Closes #374