### PR TITLE
feat(#376): verify SSH key rotation 3-state indicator

### DIFF
--- a/website/src/lib/utils/rotation-state.test.ts
+++ b/website/src/lib/utils/rotation-state.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RotationStateTracker } from './rotation-state';
+
+describe('RotationStateTracker', () => {
+	beforeEach(() => { vi.useFakeTimers(); });
+	afterEach(() => { vi.useRealTimers(); });
+
+	describe('getStatus — 3-state indicator', () => {
+		it('returns "idle" when no rotation is active or recently completed', () => {
+			const tracker = new RotationStateTracker();
+			expect(tracker.getStatus('contract-1')).toBe('idle');
+		});
+
+		it('returns "idle" when rotationRequestedAtNs is undefined', () => {
+			const tracker = new RotationStateTracker();
+			expect(tracker.getStatus('contract-1', undefined)).toBe('idle');
+		});
+
+		it('returns "in_progress" when rotationRequestedAtNs is set', () => {
+			const tracker = new RotationStateTracker();
+			expect(tracker.getStatus('contract-1', 1700000000000000000)).toBe('in_progress');
+		});
+
+		it('returns "completed" after markCompleted, overriding in_progress', () => {
+			const tracker = new RotationStateTracker();
+			tracker.markCompleted('contract-1');
+			expect(tracker.getStatus('contract-1', 1700000000000000000)).toBe('completed');
+		});
+
+		it('returns "completed" after markCompleted even without rotationRequestedAtNs', () => {
+			const tracker = new RotationStateTracker();
+			tracker.markCompleted('contract-1');
+			expect(tracker.getStatus('contract-1')).toBe('completed');
+		});
+	});
+
+	describe('recentlyCompletedRotations auto-clear after TTL', () => {
+		it('removes contract from completed set after TTL expires', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+			tracker.markCompleted('contract-1');
+			expect(tracker.isRecentlyCompleted('contract-1')).toBe(true);
+
+			vi.advanceTimersByTime(29_999);
+			expect(tracker.isRecentlyCompleted('contract-1')).toBe(true);
+
+			vi.advanceTimersByTime(1);
+			expect(tracker.isRecentlyCompleted('contract-1')).toBe(false);
+		});
+
+		it('returns to "idle" after TTL when rotationRequestedAtNs is cleared', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+			tracker.markCompleted('contract-1');
+			expect(tracker.getStatus('contract-1')).toBe('completed');
+
+			vi.advanceTimersByTime(30_000);
+			expect(tracker.getStatus('contract-1')).toBe('idle');
+		});
+
+		it('returns to "in_progress" after TTL if rotationRequestedAtNs is still set', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+			tracker.markCompleted('contract-1');
+
+			vi.advanceTimersByTime(30_000);
+			expect(tracker.getStatus('contract-1', 1700000000000000000)).toBe('in_progress');
+		});
+	});
+
+	describe('multiple concurrent rotations', () => {
+		it('tracks multiple contracts independently', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+
+			tracker.markCompleted('contract-A');
+			vi.advanceTimersByTime(15_000);
+			tracker.markCompleted('contract-B');
+
+			expect(tracker.isRecentlyCompleted('contract-A')).toBe(true);
+			expect(tracker.isRecentlyCompleted('contract-B')).toBe(true);
+
+			vi.advanceTimersByTime(15_001);
+			expect(tracker.isRecentlyCompleted('contract-A')).toBe(false);
+			expect(tracker.isRecentlyCompleted('contract-B')).toBe(true);
+
+			vi.advanceTimersByTime(15_000);
+			expect(tracker.isRecentlyCompleted('contract-B')).toBe(false);
+		});
+
+		it('re-marking same contract resets its TTL', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+
+			tracker.markCompleted('contract-1');
+			vi.advanceTimersByTime(20_000);
+
+			tracker.markCompleted('contract-1');
+			vi.advanceTimersByTime(20_000);
+			expect(tracker.isRecentlyCompleted('contract-1')).toBe(true);
+
+			vi.advanceTimersByTime(10_001);
+			expect(tracker.isRecentlyCompleted('contract-1')).toBe(false);
+		});
+	});
+
+	describe('full lifecycle: requested → in_progress → completed → idle', () => {
+		it('transitions through all 3 states correctly', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+
+			expect(tracker.getStatus('c1')).toBe('idle');
+
+			expect(tracker.getStatus('c1', 1700000000000000000)).toBe('in_progress');
+
+			tracker.markCompleted('c1');
+			expect(tracker.getStatus('c1')).toBe('completed');
+
+			vi.advanceTimersByTime(30_000);
+			expect(tracker.getStatus('c1')).toBe('idle');
+		});
+	});
+
+	describe('onChange callback', () => {
+		it('fires onChange when markCompleted is called', () => {
+			const onChange = vi.fn();
+			const tracker = new RotationStateTracker({ onChange });
+			tracker.markCompleted('c1');
+			expect(onChange).toHaveBeenCalledTimes(1);
+		});
+
+		it('fires onChange when TTL expires', () => {
+			const onChange = vi.fn();
+			const tracker = new RotationStateTracker({ ttlMs: 5_000, onChange });
+			tracker.markCompleted('c1');
+			expect(onChange).toHaveBeenCalledTimes(1);
+
+			vi.advanceTimersByTime(5_000);
+			expect(onChange).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('clearAll', () => {
+		it('removes all completed entries and cancels timers', () => {
+			const tracker = new RotationStateTracker({ ttlMs: 30_000 });
+			tracker.markCompleted('c1');
+			tracker.markCompleted('c2');
+
+			tracker.clearAll();
+			expect(tracker.isRecentlyCompleted('c1')).toBe(false);
+			expect(tracker.isRecentlyCompleted('c2')).toBe(false);
+
+			vi.advanceTimersByTime(60_000);
+			expect(tracker.isRecentlyCompleted('c1')).toBe(false);
+			expect(tracker.isRecentlyCompleted('c2')).toBe(false);
+		});
+	});
+});

--- a/website/src/lib/utils/rotation-state.ts
+++ b/website/src/lib/utils/rotation-state.ts
@@ -1,0 +1,59 @@
+export type RotationStatus = 'idle' | 'in_progress' | 'completed';
+
+export class RotationStateTracker {
+	private completed: Set<string> = new Set();
+	private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+	private ttlMs: number;
+	private onChange?: () => void;
+
+	get completedSet(): Readonly<Set<string>> {
+		return this.completed;
+	}
+
+	constructor(options?: { ttlMs?: number; onChange?: () => void }) {
+		this.ttlMs = options?.ttlMs ?? 30_000;
+		this.onChange = options?.onChange;
+	}
+
+	getStatus(contractId: string, rotationRequestedAtNs?: number): RotationStatus {
+		if (this.completed.has(contractId)) return 'completed';
+		if (rotationRequestedAtNs !== undefined && rotationRequestedAtNs !== null) return 'in_progress';
+		return 'idle';
+	}
+
+	isRecentlyCompleted(contractId: string): boolean {
+		return this.completed.has(contractId);
+	}
+
+	markCompleted(contractId: string): void {
+		this.clearTimer(contractId);
+		const next = new Set(this.completed);
+		next.add(contractId);
+		this.completed = next;
+		this.onChange?.();
+		const timer = setTimeout(() => {
+			const after = new Set(this.completed);
+			after.delete(contractId);
+			this.completed = after;
+			this.timers.delete(contractId);
+			this.onChange?.();
+		}, this.ttlMs);
+		this.timers.set(contractId, timer);
+	}
+
+	clearAll(): void {
+		for (const timer of this.timers.values()) {
+			clearTimeout(timer);
+		}
+		this.timers.clear();
+		this.completed = new Set();
+	}
+
+	private clearTimer(contractId: string): void {
+		const existing = this.timers.get(contractId);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+			this.timers.delete(contractId);
+		}
+	}
+}

--- a/website/src/routes/dashboard/rentals/+page.svelte
+++ b/website/src/routes/dashboard/rentals/+page.svelte
@@ -28,6 +28,7 @@
 	import { signRequest } from "$lib/services/auth-api";
 	import { UserApiClient } from "$lib/services/user-api";
 	import { buildContractEventsUrl, parseContractEvent, parseSshKeyRotationEvent } from "$lib/utils/contract-sse";
+	import { RotationStateTracker } from "$lib/utils/rotation-state";
 	import { get } from "svelte/store";
 	import type { Ed25519KeyIdentity } from "@dfinity/identity";
 
@@ -50,6 +51,9 @@
 		typeof sessionStorage !== 'undefined' && sessionStorage.getItem('pending_guidance_dismissed') === '1'
 	);
 	let recentlyCompletedRotations = $state<Set<string>>(new Set());
+	let rotationTracker = new RotationStateTracker({
+		onChange: () => { recentlyCompletedRotations = new Set(rotationTracker.completedSet); }
+	});
 
 	const spendingStats = $derived({
 		total: contracts.length,
@@ -201,14 +205,7 @@
 						? { ...c, ssh_key_rotation_requested_at_ns: undefined }
 						: c
 				);
-				const updated = new Set(recentlyCompletedRotations);
-				updated.add(rotation.contract_id);
-				recentlyCompletedRotations = updated;
-				setTimeout(() => {
-					const next = new Set(recentlyCompletedRotations);
-					next.delete(rotation.contract_id);
-					recentlyCompletedRotations = next;
-				}, 30_000);
+				rotationTracker.markCompleted(rotation.contract_id);
 			} catch (e) {
 				console.error('[Rentals] Failed to parse ssh_key_rotation_complete SSE event:', e);
 			}
@@ -223,6 +220,8 @@
 			eventSource = null;
 			sseConnected = false;
 		}
+		rotationTracker.clearAll();
+		recentlyCompletedRotations = new Set();
 	}
 
 	async function refreshContracts() {


### PR DESCRIPTION
## Summary
Post-merge verification for #254 / PR #375. Extracts the rotation state management from the Svelte component into a testable `RotationStateTracker` utility and adds 14 automated tests covering all 3 indicator states and edge cases.

**Problem:** The rotation indicator logic (recently completed tracking + 30s auto-clear) was embedded inline in `+page.svelte` with no test coverage. The PR #375 test plan had an unchecked manual verification item.

**Changes:**
- **New:** `website/src/lib/utils/rotation-state.ts` — `RotationStateTracker` class encapsulating completed-rotation Set, TTL-based auto-dismiss, and cleanup
- **New:** `website/src/lib/utils/rotation-state.test.ts` — 14 tests covering:
  - 3-state indicator: `idle` → `in_progress` → `completed` → `idle`
  - TTL auto-clear at exactly 30s boundary
  - Multiple concurrent rotations tracked independently
  - Re-marking same contract resets its TTL
  - `onChange` callback fires on mark and on expiry
  - `clearAll()` cancels all timers and clears state
- **Refactored:** `+page.svelte` SSE handler uses `RotationStateTracker` instead of inline Set+setTimeout
- **Improved:** `closeSSE()` now calls `rotationTracker.clearAll()` to prevent timer leaks

## Verification
- `npm run check` — 0 errors, 0 warnings
- Full Vitest suite — **853/853** tests pass (839 existing + 14 new)
- Backend validation: N/A (frontend-only change, no backend interaction)

## Test plan
- [x] Automated: all 14 `rotation-state.test.ts` tests pass
- [x] Automated: full suite 853/853 green
- [x] Automated: svelte-check clean
- [ ] Manual (staging): trigger SSH key rotation, verify amber spinner → green checkmark → auto-dismiss on rentals list

Closes #376