### PR TITLE
fix(#378): add error logging for silent-swallow DB patterns in SSE/webhook handlers

### DIFF
--- a/api/src/openapi/cloud.rs
+++ b/api/src/openapi/cloud.rs
@@ -729,13 +729,33 @@ impl CloudApi {
         };
 
         // Auto-unlist from marketplace if listed
-        if let Ok(Some(resource)) = db.get_cloud_resource(&uuid, &account_id).await {
-            if resource.resource.listing_mode == "marketplace" {
-                if let Ok(old_offering_id) = db.unlist_from_marketplace(&uuid, &account_id).await {
-                    if let Err(e) = db.delete_offering(&user.pubkey, old_offering_id).await {
-                        tracing::warn!(resource_id = %uuid, offering_id = old_offering_id, "Failed to delete offering during resource deletion: {e:#}");
+        match db.get_cloud_resource(&uuid, &account_id).await {
+            Ok(Some(resource)) => {
+                if resource.resource.listing_mode == "marketplace" {
+                    match db.unlist_from_marketplace(&uuid, &account_id).await {
+                        Ok(old_offering_id) => {
+                            if let Err(e) = db.delete_offering(&user.pubkey, old_offering_id).await
+                            {
+                                tracing::warn!(resource_id = %uuid, offering_id = old_offering_id, "Failed to delete offering during resource deletion: {e:#}");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                resource_id = %uuid,
+                                "Failed to unlist from marketplace during resource deletion: {e:#}"
+                            );
+                        }
                     }
                 }
+            }
+            Ok(None) => {
+                tracing::warn!(resource_id = %uuid, "Cloud resource not found for marketplace unlist check");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    resource_id = %uuid,
+                    "Failed to fetch cloud resource for marketplace unlist check: {e:#}"
+                );
             }
         }
 

--- a/api/src/openapi/contracts.rs
+++ b/api/src/openapi/contracts.rs
@@ -367,17 +367,33 @@ impl ContractsApi {
 
         match db.request_password_reset(&contract_id).await {
             Ok(_) => {
-                if let Ok(Some(full_contract)) = db.get_contract(&contract_id).await {
-                    if let Err(e) = crate::rental_notifications::notify_provider_password_reset(
-                        db.as_ref(),
-                        email_service.as_ref(),
-                        &full_contract,
-                        false,
-                    )
-                    .await
-                    {
+                match db.get_contract(&contract_id).await {
+                    Ok(Some(full_contract)) => {
+                        if let Err(e) =
+                            crate::rental_notifications::notify_provider_password_reset(
+                                db.as_ref(),
+                                email_service.as_ref(),
+                                &full_contract,
+                                false,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "Failed to notify provider of password reset for contract {}: {}",
+                                hex::encode(&contract_id),
+                                e
+                            );
+                        }
+                    }
+                    Ok(None) => {
                         tracing::warn!(
-                            "Failed to notify provider of password reset for contract {}: {}",
+                            "Contract {} not found after password reset request",
+                            hex::encode(&contract_id)
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to fetch contract {} for password reset notification: {:#}",
                             hex::encode(&contract_id),
                             e
                         );

--- a/api/src/openapi/providers.rs
+++ b/api/src/openapi/providers.rs
@@ -2267,30 +2267,39 @@ impl ProvidersApi {
         {
             Ok((success_count, mut errors)) => {
                 // Post-import: validate cloud offerings against live catalog
-                if let Ok(offerings) = db.get_provider_offerings(&pubkey_bytes).await {
-                    for offering in offerings.iter().filter(|o| {
-                        matches!(
-                            o.provisioner_type.as_deref(),
-                            Some("hetzner") | Some("vultr")
-                        )
-                    }) {
-                        if let Err(e) =
-                            validate_cloud_offering(&db, offering, &pubkey_bytes).await
-                        {
-                            errors.push((
-                                0,
-                                format!(
-                                    "{} validation failed for offering '{}': {}",
-                                    offering
-                                        .provisioner_type
-                                        .as_deref()
-                                        .unwrap_or("unknown")
-                                        .to_uppercase(),
-                                    offering.offering_id,
-                                    e
-                                ),
-                            ));
+                match db.get_provider_offerings(&pubkey_bytes).await {
+                    Ok(offerings) => {
+                        for offering in offerings.iter().filter(|o| {
+                            matches!(
+                                o.provisioner_type.as_deref(),
+                                Some("hetzner") | Some("vultr")
+                            )
+                        }) {
+                            if let Err(e) =
+                                validate_cloud_offering(&db, offering, &pubkey_bytes).await
+                            {
+                                errors.push((
+                                    0,
+                                    format!(
+                                        "{} validation failed for offering '{}': {}",
+                                        offering
+                                            .provisioner_type
+                                            .as_deref()
+                                            .unwrap_or("unknown")
+                                            .to_uppercase(),
+                                        offering.offering_id,
+                                        e
+                                    ),
+                                ));
+                            }
                         }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "CSV import post-validation: failed to fetch offerings for provider {}: {:#}",
+                            hex::encode(&pubkey_bytes),
+                            e
+                        );
                     }
                 }
 
@@ -2702,18 +2711,33 @@ impl ProvidersApi {
                         }
 
                         // Notify user that their VM is ready
-                        if let Ok(Some(contract)) = db.get_contract(&contract_id).await {
-                            if let Err(e) = crate::rental_notifications::notify_user_provisioned(
-                                &db,
-                                email_service.as_ref(),
-                                &contract,
-                                details,
-                            )
-                            .await
-                            {
-                                // Log but don't fail - provisioning succeeded
+                        match db.get_contract(&contract_id).await {
+                            Ok(Some(contract)) => {
+                                if let Err(e) =
+                                    crate::rental_notifications::notify_user_provisioned(
+                                        &db,
+                                        email_service.as_ref(),
+                                        &contract,
+                                        details,
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "Failed to send provisioned notification for contract {}: {}",
+                                        &id.0[..16],
+                                        e
+                                    );
+                                }
+                            }
+                            Ok(None) => {
                                 tracing::warn!(
-                                    "Failed to send provisioned notification for contract {}: {}",
+                                    "Contract {} not found after provisioning status update",
+                                    &id.0[..16]
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to fetch contract {} for provisioned notification: {:#}",
                                     &id.0[..16],
                                     e
                                 );

--- a/api/src/openapi/webhooks.rs
+++ b/api/src/openapi/webhooks.rs
@@ -267,20 +267,34 @@ pub async fn stripe_webhook(
             );
 
             // Notify provider about new rental request
-            if let Ok(Some(contract)) = db.get_contract(&contract_id_bytes).await {
-                if let Err(e) = crate::rental_notifications::notify_provider_new_rental(
-                    db.as_ref(),
-                    email_service.as_ref(),
-                    &contract,
-                )
-                .await
-                {
+            match db.get_contract(&contract_id_bytes).await {
+                Ok(Some(contract)) => {
+                    if let Err(e) = crate::rental_notifications::notify_provider_new_rental(
+                        db.as_ref(),
+                        email_service.as_ref(),
+                        &contract,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            "Failed to notify provider for contract {}: {}",
+                            contract_id_hex,
+                            e
+                        );
+                    }
+                }
+                Ok(None) => {
                     tracing::warn!(
-                        "Failed to notify provider for contract {}: {}",
+                        "Contract {} not found after payment succeeded",
+                        contract_id_hex
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to fetch contract {} for provider notification after payment: {:#}",
                         contract_id_hex,
                         e
                     );
-                    // Don't fail the webhook - payment succeeded
                 }
             }
 
@@ -1038,20 +1052,35 @@ pub async fn icpay_webhook(
                         );
 
                         // Notify provider about new rental request
-                        if let Ok(Some(contract)) = db.get_contract(&contract_id_bytes).await {
-                            if let Err(e) = crate::rental_notifications::notify_provider_new_rental(
-                                db.as_ref(),
-                                email_service.as_ref(),
-                                &contract,
-                            )
-                            .await
-                            {
+                        match db.get_contract(&contract_id_bytes).await {
+                            Ok(Some(contract)) => {
+                                if let Err(e) =
+                                    crate::rental_notifications::notify_provider_new_rental(
+                                        db.as_ref(),
+                                        email_service.as_ref(),
+                                        &contract,
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "Failed to notify provider for contract {}: {}",
+                                        contract_id_hex,
+                                        e
+                                    );
+                                }
+                            }
+                            Ok(None) => {
                                 tracing::warn!(
-                                    "Failed to notify provider for contract {}: {}",
+                                    "Contract {} not found after ICPay payment succeeded",
+                                    contract_id_hex
+                                );
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to fetch contract {} for provider notification after ICPay payment: {:#}",
                                     contract_id_hex,
                                     e
                                 );
-                                // Don't fail the webhook - payment succeeded
                             }
                         }
 


### PR DESCRIPTION
## Summary

Follow-up from #253 / PR #377. Converts 7 remaining `if let Ok(...)` patterns that silently swallow DB errors to `match` with proper `tracing::warn!` / `tracing::error!` logging on the `Err` branch.

### What changed

**4 files, 7 patterns converted:**

| File | Query | Log level | Rationale |
|------|-------|-----------|-----------|
| `providers.rs` | `get_provider_offerings` (CSV import post-validation) | `warn` | Supplementary validation after main import |
| `providers.rs` | `get_contract` (provisioning status SSE notification) | `warn` | Notification is supplementary; provisioning already succeeded |
| `contracts.rs` | `get_contract` (password reset SSE notification) | `warn` | Notification is supplementary; reset already requested |
| `cloud.rs` | `get_cloud_resource` + `unlist_from_marketplace` (resource deletion) | `warn` | Marketplace cleanup is supplementary to main deletion |
| `webhooks.rs` | `get_contract` (Stripe payment webhook) | `error` | Primary data fetch — contract should exist after payment |
| `webhooks.rs` | `get_contract` (ICPay payment webhook) | `error` | Primary data fetch — contract should exist after payment |

Also logs `Ok(None)` cases (contract/resource not found after operation) at `warn` level for observability.

### Test plan
- `cargo clippy -p api --tests` — clean
- `cargo build -p api --tests` — clean
- Non-DB unit tests pass (DB tests require PostgreSQL, will run in CI)
- No behavioral change — only adds logging to previously-silent error paths

### Out of scope
Confirmed no remaining `if let Ok(...) = db.` patterns in `api/src/`.