### PR TITLE
fix(#384): prevent Vultr resource leak when instance has no public IP

### DIFF
--- a/api/src/cloud/vultr.rs
+++ b/api/src/cloud/vultr.rs
@@ -19,6 +19,7 @@ use crate::cloud::types::{
 
 const VULTR_API_BASE: &str = "https://api.vultr.com/v2";
 const REQUEST_TIMEOUT_SECS: u64 = 30;
+const IP_ASSIGNMENT_TIMEOUT_SECS: u64 = 120;
 
 pub struct VultrBackend {
     client: Client,
@@ -559,11 +560,35 @@ impl CloudBackend for VultrBackend {
             anyhow::bail!("Server failed to reach running state: {:?}", server.status);
         }
 
-        if let Some(ref ip) = server.public_ip {
-            if !self.wait_for_ssh_reachable(ip, 120).await? {
-                cleanup_server_and_key(self, &server.id, &ssh_key_id).await;
-                anyhow::bail!("SSH port not reachable after 120s");
+        if server.public_ip.is_none() {
+            let ip_wait_start = std::time::Instant::now();
+            let ip_timeout = std::time::Duration::from_secs(IP_ASSIGNMENT_TIMEOUT_SECS);
+            while server.public_ip.is_none() && ip_wait_start.elapsed() < ip_timeout {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                match self.get_server(&server.id).await {
+                    Ok(s) => server = s,
+                    Err(e) => {
+                        tracing::warn!("Error polling server {} for IP: {:#}", server.id, e);
+                    }
+                }
             }
+        }
+
+        let ip = match server.public_ip {
+            Some(ref ip) => ip.clone(),
+            None => {
+                cleanup_server_and_key(self, &server.id, &ssh_key_id).await;
+                anyhow::bail!(
+                    "Server {} reached running state but never got a public IP within {}s",
+                    server.id,
+                    IP_ASSIGNMENT_TIMEOUT_SECS
+                );
+            }
+        };
+
+        if !self.wait_for_ssh_reachable(&ip, 120).await? {
+            cleanup_server_and_key(self, &server.id, &ssh_key_id).await;
+            anyhow::bail!("SSH port not reachable after 120s");
         }
 
         Ok(ProvisionResult {

--- a/api/src/cloud_provisioning_service.rs
+++ b/api/src/cloud_provisioning_service.rs
@@ -214,10 +214,17 @@ async fn provision_one(
 
     let result = backend.create_server(request).await?;
 
-    let public_ip = result
-        .server
-        .public_ip
-        .ok_or_else(|| anyhow::anyhow!("Server has no public IP"))?;
+    let public_ip = match result.server.public_ip {
+        Some(ip) => ip,
+        None => {
+            let ssh_key_id = result.ssh_key_id.unwrap_or_default();
+            cleanup_failed_provision(&*backend, &result.server.id, &ssh_key_id).await;
+            anyhow::bail!(
+                "Server {} has no public IP after provisioning",
+                result.server.id
+            );
+        }
+    };
     let ssh_key_id = result.ssh_key_id.unwrap_or_default();
 
     // Execute post-provision script if present (recipe provisioning)


### PR DESCRIPTION
## Summary

Fixes #384 — Vultr instances that reach `active` status but have `main_ip = 0.0.0.0` would leave orphaned VMs and SSH keys.

## Problem

When a Vultr instance reaches active but `main_ip` is still `0.0.0.0`:
1. `vultr.rs create_server()` converts `0.0.0.0` to `public_ip=None`
2. SSH reachability check is silently skipped (`if let Some(ref ip)`)
3. `create_server` returns `Ok` with `public_ip=None`
4. `provision_one` fails with "Server has no public IP"
5. **The VM and SSH key are never cleaned up** — resource leak

## Fix (two parts)

### 1. `api/src/cloud/vultr.rs` — IP wait loop in `create_server()`
After server reaches `Running` status, if `public_ip` is `None`, poll `get_server()` in a loop (5s intervals, up to 120s timeout) until a real IP is assigned. If IP never appears, clean up server + SSH key and return error.

### 2. `api/src/cloud_provisioning_service.rs` — defense-in-depth cleanup
If *any* backend returns `Ok` with `public_ip=None`, call `cleanup_failed_provision` to delete the VM and SSH key before returning the error. This catches edge cases even if a backend doesn't handle it internally.

## Files changed
- `api/src/cloud/vultr.rs` — added `IP_ASSIGNMENT_TIMEOUT_SECS` constant and IP wait loop after Running status check
- `api/src/cloud_provisioning_service.rs` — replaced `ok_or_else` with `match` that cleans up on `None`

## Testing
- All existing vultr unit tests pass (22 tests)
- All provisioning service tests pass (2 tests)
- `cargo clippy -p api --tests` clean
- DB integration tests require PostgreSQL (pre-existing, unrelated)

## Similar patterns checked
- **Hetzner**: structurally safe — IP is non-optional in API response, deserialization fails before reaching this code
- **Proxmox API**: `create_server` always bails, no leak possible
- **DigitalOcean** (dc-agent): has same pattern but is in a different crate, out of scope for this ticket