### PR TITLE
fix(#385): remove try_trigger_hetzner_provisioning backward-compat alias

### DIFF
--- a/api/src/database/contracts/provisioning.rs
+++ b/api/src/database/contracts/provisioning.rs
@@ -790,11 +790,6 @@ impl Database {
         Ok(true)
     }
 
-    /// Backwards-compatible alias — delegates to try_trigger_cloud_provisioning.
-    pub async fn try_trigger_hetzner_provisioning(&self, contract_id: &[u8]) -> Result<bool> {
-        self.try_trigger_cloud_provisioning(contract_id).await
-    }
-
     // ==================== Cloud Resource Provisioning Bridge ====================
 
     /// Update contract to active after cloud_resource provisioning completes.

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1090,7 +1090,7 @@ async fn serve_command() -> Result<(), std::io::Error> {
         }
         Err(_) => {
             tracing::warn!(
-                "CREDENTIAL_ENCRYPTION_KEY not set — cloud account management (Hetzner/Proxmox) will NOT work! \
+                "CREDENTIAL_ENCRYPTION_KEY not set — cloud account management (Hetzner/Proxmox/Vultr) will NOT work! \
                  Generate with: openssl rand -hex 32"
             );
         }

--- a/api/src/openapi/contracts.rs
+++ b/api/src/openapi/contracts.rs
@@ -742,11 +742,11 @@ impl ContractsApi {
                                 );
                             }
 
-                            // Auto-accepted, try to trigger Hetzner provisioning
-                            if let Err(e) = db.try_trigger_hetzner_provisioning(&contract_id).await
+                            // Auto-accepted, try to trigger cloud provisioning
+                            if let Err(e) = db.try_trigger_cloud_provisioning(&contract_id).await
                             {
                                 tracing::warn!(
-                                    "Hetzner provisioning trigger failed for contract {}: {}",
+                                    "Cloud provisioning trigger failed for contract {}: {}",
                                     hex::encode(&contract_id),
                                     e
                                 );
@@ -1407,11 +1407,11 @@ impl ContractsApi {
         match db.try_auto_accept_contract(&contract_id_bytes).await {
             Ok(true) => {
                 if let Err(e) = db
-                    .try_trigger_hetzner_provisioning(&contract_id_bytes)
+                    .try_trigger_cloud_provisioning(&contract_id_bytes)
                     .await
                 {
                     tracing::warn!(
-                        "Hetzner provisioning trigger failed for contract {}: {}",
+                        "Cloud provisioning trigger failed for contract {}: {}",
                         session_result.contract_id,
                         e
                     );


### PR DESCRIPTION
## Summary
Closes #385

- Remove `try_trigger_hetzner_provisioning` backward-compat alias from `provisioning.rs` (DRY violation)
- Update 2 callers in `openapi/contracts.rs` to call `try_trigger_cloud_provisioning` directly
- Update `main.rs` startup warning to mention Vultr alongside Hetzner/Proxmox
- Also updates log messages from "Hetzner provisioning" to "Cloud provisioning" for accuracy

## Files changed
- `api/src/database/contracts/provisioning.rs` — removed alias (5 lines)
- `api/src/openapi/contracts.rs` — updated 2 call sites (lines 746, 1410) + log messages
- `api/src/main.rs` — updated startup warning message

## Test plan
- `cargo clippy -p api --tests` — clean (verified locally)
- Dead code removal only, no behavioral change
- CI will run full test suite