### PR TITLE
feat(#397): add IP wait loop for DigitalOcean provisioner

### DIFF
--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -304,6 +304,37 @@ impl DigitalOceanProvisioner {
         );
     }
 
+    async fn wait_for_droplet_ip(&self, droplet_id: i64, max_retries: u32) -> Result<Droplet> {
+        for attempt in 0..max_retries {
+            let droplet = self
+                .get_droplet(droplet_id)
+                .await?
+                .context("Droplet disappeared while waiting for IP address")?;
+
+            if droplet.public_ipv4().is_some() || droplet.public_ipv6().is_some() {
+                tracing::info!(
+                    droplet_id,
+                    ipv4 = ?droplet.public_ipv4(),
+                    ipv6 = ?droplet.public_ipv6(),
+                    "Droplet has IP address"
+                );
+                return Ok(droplet);
+            }
+
+            tracing::debug!(
+                droplet_id,
+                attempt,
+                "Waiting for droplet to be assigned an IP address"
+            );
+            tokio::time::sleep(self.poll_interval).await;
+        }
+        bail!(
+            "Droplet {} is active but no IP address assigned within {} retries",
+            droplet_id,
+            max_retries
+        );
+    }
+
     async fn create_ssh_key(&self, name: &str, public_key: &str) -> Result<i64> {
         #[derive(Serialize)]
         struct CreateSshKeyRequest {
@@ -539,16 +570,8 @@ impl Provisioner for DigitalOceanProvisioner {
         let droplet_id = droplet_resp.droplet.id;
         tracing::info!(droplet_id, "Droplet created, waiting for active state");
 
-        match self.wait_for_droplet_active(droplet_id, 60).await {
-            Ok(droplet) => {
-                let instance = self.droplet_to_instance(&droplet);
-                tracing::info!(
-                    droplet_id,
-                    ip = ?instance.ip_address,
-                    "Droplet provisioned successfully"
-                );
-                Ok(instance)
-            }
+        let active_droplet = match self.wait_for_droplet_active(droplet_id, 60).await {
+            Ok(droplet) => droplet,
             Err(e) => {
                 tracing::error!(droplet_id, error = %e, "Droplet failed to become active, cleaning up");
                 if let Err(cleanup_err) = self
@@ -566,9 +589,47 @@ impl Provisioner for DigitalOceanProvisioner {
                         tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
                     }
                 }
-                Err(e)
+                return Err(e);
             }
-        }
+        };
+
+        let droplet = if active_droplet.public_ipv4().is_none()
+            && active_droplet.public_ipv6().is_none()
+        {
+            tracing::info!(droplet_id, "Droplet active but no IP yet, waiting for IP assignment");
+            match self.wait_for_droplet_ip(droplet_id, 12).await {
+                Ok(droplet) => droplet,
+                Err(e) => {
+                    tracing::error!(droplet_id, error = %e, "Droplet never got IP, cleaning up");
+                    if let Err(cleanup_err) = self
+                        .request_builder(
+                            reqwest::Method::DELETE,
+                            &format!("/v2/droplets/{}", droplet_id),
+                        )
+                        .send()
+                        .await
+                    {
+                        tracing::warn!(droplet_id, error = %cleanup_err, "Failed to delete droplet during cleanup");
+                    }
+                    if let Some(key_id) = created_ssh_key_id {
+                        if let Err(key_err) = self.delete_ssh_key(key_id).await {
+                            tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
+                        }
+                    }
+                    return Err(e);
+                }
+            }
+        } else {
+            active_droplet
+        };
+
+        let instance = self.droplet_to_instance(&droplet);
+        tracing::info!(
+            droplet_id,
+            ip = ?instance.ip_address,
+            "Droplet provisioned successfully"
+        );
+        Ok(instance)
     }
 
     async fn terminate(&self, external_id: &str) -> Result<()> {

--- a/dc-agent/src/provisioner/digitalocean_tests.rs
+++ b/dc-agent/src/provisioner/digitalocean_tests.rs
@@ -33,6 +33,13 @@ fn active_droplet_json(id: i64, name: &str) -> String {
     )
 }
 
+fn active_droplet_no_ip_json(id: i64, name: &str) -> String {
+    format!(
+        r#"{{"id":{},"name":"{}","status":"active","memory":1024,"vcpus":1,"disk":25,"locked":false,"created_at":"2020-07-21T18:37:44Z","networks":{{"v4":[],"v6":[]}},"region":{{"name":"New York 3","slug":"nyc3"}},"size_slug":"s-1vcpu-1gb","tags":["dc-agent"],"features":[]}}"#,
+        id, name
+    )
+}
+
 fn new_droplet_json(id: i64, name: &str) -> String {
     format!(
         r#"{{"id":{},"name":"{}","status":"new","memory":1024,"vcpus":1,"disk":25,"locked":false,"created_at":"2020-07-21T18:37:44Z","networks":{{"v4":[],"v6":[]}},"region":{{"name":"New York 3","slug":"nyc3"}},"size_slug":"s-1vcpu-1gb","tags":["dc-agent"],"features":[]}}"#,
@@ -881,6 +888,97 @@ async fn test_collect_resources_api_failure_returns_none() {
     let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
     let result = prov.collect_resources().await;
     assert!(result.is_none(), "collect_resources should return None on API failure");
+}
+
+#[tokio::test]
+async fn test_provision_active_then_ip_assigned() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(77777, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let _get_active_no_ip = server
+        .mock("GET", "/v2/droplets/77777")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_no_ip_json(77777, "dc-test-contract-123")
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let _get_active_with_ip = server
+        .mock("GET", "/v2/droplets/77777")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_json(77777, "dc-test-contract-123")
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request()).await;
+    assert!(result.is_ok(), "provision should succeed after IP is assigned: {:?}", result.err());
+
+    let instance = result.unwrap();
+    assert_eq!(instance.external_id, "77777");
+    assert_eq!(instance.ip_address.as_deref(), Some("192.241.165.154"));
+}
+
+#[tokio::test]
+async fn test_provision_active_never_gets_ip() {
+    let mut server = mockito::Server::new_async().await;
+
+    let _create = server
+        .mock("POST", "/v2/droplets")
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            new_droplet_json(88888, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let _get_active_no_ip = server
+        .mock("GET", "/v2/droplets/88888")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"droplet":{}}}"#,
+            active_droplet_no_ip_json(88888, "dc-test-contract-123")
+        ))
+        .create_async()
+        .await;
+
+    let _delete = server
+        .mock("DELETE", mockito::Matcher::Any)
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let prov = DigitalOceanProvisioner::new_for_mockito(server.url());
+    let result = prov.provision(&make_provision_request()).await;
+    assert!(result.is_err(), "provision should fail when droplet never gets IP");
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(
+        err.contains("no IP address assigned"),
+        "Error should mention IP wait failure: {}",
+        err
+    );
 }
 
 // ── Integration test (requires DIGITALOCEAN_API_TOKEN env var) ──────────────


### PR DESCRIPTION
## Summary
- Add `wait_for_droplet_ip()` method that polls `get_droplet` until a public IPv4 or IPv6 is assigned (12 retries at 5s = 60s total)
- Integrate into `provision()` flow: after droplet becomes active, if no IP is present yet, enter the IP wait loop
- Full cleanup (droplet delete + SSH key removal) on IP wait timeout, matching the existing active-state timeout behavior
- Follows the same pattern as the Proxmox IP wait loop

## Why
The DO API can mark a droplet as "active" before network info (IPs) is populated. Without this wait loop, the provisioner would return an `Instance` with `ip_address: None`, making the VM unreachable.

## Test plan
- `test_provision_active_then_ip_assigned` — droplet active without IP, IP appears on re-poll → provision succeeds
- `test_provision_active_never_gets_ip` — droplet active, IP never appears → provision fails with cleanup
- Existing tests continue passing (no regressions)
- Full suite: 225 tests pass (210 lib + 15 binary)