### PR TITLE
refactor(#402): extract cleanup_droplet_and_key helper from duplicated cleanup blocks

### DIFF
--- a/dc-agent/src/provisioner/digitalocean.rs
+++ b/dc-agent/src/provisioner/digitalocean.rs
@@ -335,6 +335,24 @@ impl DigitalOceanProvisioner {
         );
     }
 
+    async fn cleanup_droplet_and_key(&self, droplet_id: i64, ssh_key_id: Option<i64>) {
+        if let Err(cleanup_err) = self
+            .request_builder(
+                reqwest::Method::DELETE,
+                &format!("/v2/droplets/{}", droplet_id),
+            )
+            .send()
+            .await
+        {
+            tracing::warn!(droplet_id, error = %cleanup_err, "Failed to delete droplet during cleanup");
+        }
+        if let Some(key_id) = ssh_key_id {
+            if let Err(key_err) = self.delete_ssh_key(key_id).await {
+                tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
+            }
+        }
+    }
+
     async fn create_ssh_key(&self, name: &str, public_key: &str) -> Result<i64> {
         #[derive(Serialize)]
         struct CreateSshKeyRequest {
@@ -574,21 +592,7 @@ impl Provisioner for DigitalOceanProvisioner {
             Ok(droplet) => droplet,
             Err(e) => {
                 tracing::error!(droplet_id, error = %e, "Droplet failed to become active, cleaning up");
-                if let Err(cleanup_err) = self
-                    .request_builder(
-                        reqwest::Method::DELETE,
-                        &format!("/v2/droplets/{}", droplet_id),
-                    )
-                    .send()
-                    .await
-                {
-                    tracing::warn!(droplet_id, error = %cleanup_err, "Failed to delete droplet during cleanup");
-                }
-                if let Some(key_id) = created_ssh_key_id {
-                    if let Err(key_err) = self.delete_ssh_key(key_id).await {
-                        tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
-                    }
-                }
+                self.cleanup_droplet_and_key(droplet_id, created_ssh_key_id).await;
                 return Err(e);
             }
         };
@@ -601,21 +605,7 @@ impl Provisioner for DigitalOceanProvisioner {
                 Ok(droplet) => droplet,
                 Err(e) => {
                     tracing::error!(droplet_id, error = %e, "Droplet never got IP, cleaning up");
-                    if let Err(cleanup_err) = self
-                        .request_builder(
-                            reqwest::Method::DELETE,
-                            &format!("/v2/droplets/{}", droplet_id),
-                        )
-                        .send()
-                        .await
-                    {
-                        tracing::warn!(droplet_id, error = %cleanup_err, "Failed to delete droplet during cleanup");
-                    }
-                    if let Some(key_id) = created_ssh_key_id {
-                        if let Err(key_err) = self.delete_ssh_key(key_id).await {
-                            tracing::warn!(key_id, error = %key_err, "Failed to clean up SSH key during droplet cleanup");
-                        }
-                    }
+                    self.cleanup_droplet_and_key(droplet_id, created_ssh_key_id).await;
                     return Err(e);
                 }
             }


### PR DESCRIPTION
## Summary

Extracts the duplicated droplet-delete + SSH-key-removal cleanup logic from the `provision()` method in the DigitalOcean provisioner into a shared `cleanup_droplet_and_key()` helper.

PR #400 introduced IP-wait timeout logic that duplicated the cleanup block between:
1. The active-state timeout path (droplet failed to become active)
2. The IP-wait timeout path (droplet became active but never got an IP)

Both paths performed identical cleanup: DELETE the droplet via API, then delete the SSH key if one was created. The only difference was the error log message, which is preserved at each call site.

## Changes
- **1 file changed**: `dc-agent/src/provisioner/digitalocean.rs`
- Added `cleanup_droplet_and_key(droplet_id, ssh_key_id)` private async method
- Replaced both duplicated cleanup blocks with calls to the new helper
- Net: 20 lines added, 30 lines removed

## Test Plan
- All 37 existing DigitalOcean tests pass (including `test_provision_active_never_gets_ip` and `test_provision_droplet_never_becomes_active` which exercise both cleanup paths)
- `cargo clippy -p dc-agent --tests` passes with no new warnings
- This is a pure refactoring with no behavior change — existing tests fully cover both code paths

Closes #402