### PR TITLE
test(#84): add tests for database handlers.rs

### DIFF
--- a/api/src/database/handlers.rs
+++ b/api/src/database/handlers.rs
@@ -382,6 +382,143 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_insert_entries_empty_vec_returns_ok() {
+        let db = setup_test_db().await;
+        let result = db.insert_entries(vec![]).await;
+        assert!(result.is_ok(), "Empty entries should return Ok immediately");
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_prov_register() {
+        let db = setup_test_db().await;
+
+        let entries = vec![make_entry(
+            LABEL_PROV_REGISTER,
+            b"prov_provider_key",
+            b"prov_signature",
+            1_000_000_000,
+            1,
+        )];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_registrations").await,
+            1,
+            "PROV_REGISTER should dispatch to provider_registrations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_legacy_64byte_check_in_fallback() {
+        let db = setup_test_db().await;
+
+        let provider_key = b"legacy_checkin_provider";
+        let legacy_nonce = vec![0xABu8; 64];
+
+        let entries = vec![
+            make_entry(LABEL_PROV_REGISTER, provider_key, b"sig", 1_000_000_000, 1),
+            make_entry(
+                LABEL_PROV_CHECK_IN,
+                provider_key,
+                &legacy_nonce,
+                1_100_000_000,
+                2,
+            ),
+        ];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_check_ins").await,
+            1,
+            "Legacy 64-byte nonce should be accepted as check-in"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_provider_registration_upsert() {
+        let db = setup_test_db().await;
+
+        let provider_key = b"upsert_provider";
+
+        let entries_v1 = vec![make_entry(
+            LABEL_PROV_REGISTER,
+            provider_key,
+            b"signature_v1",
+            1_000_000_000,
+            1,
+        )];
+        db.insert_entries(entries_v1).await.unwrap();
+
+        assert_eq!(count_rows(&db, "provider_registrations").await, 1);
+
+        let entries_v2 = vec![make_entry(
+            LABEL_PROV_REGISTER,
+            provider_key,
+            b"signature_v2",
+            2_000_000_000,
+            2,
+        )];
+        db.insert_entries(entries_v2).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_registrations").await,
+            1,
+            "Upsert should not create duplicate rows"
+        );
+
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT signature FROM provider_registrations WHERE pubkey != $1",
+        )
+        .bind(Database::example_provider_pubkey())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        let sig: Vec<u8> = row.get("signature");
+        assert_eq!(
+            sig, b"signature_v2",
+            "Upsert should update the signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_mixed_prov_and_np_register_same_batch() {
+        let db = setup_test_db().await;
+
+        let entries = vec![
+            make_entry(LABEL_PROV_REGISTER, b"prov_key", b"prov_sig", 1_000_000_000, 1),
+            make_entry(LABEL_NP_REGISTER, b"np_key", b"np_sig", 1_100_000_000, 2),
+        ];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_registrations").await,
+            2,
+            "Both PROV_REGISTER and NP_REGISTER should insert into provider_registrations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_user_register() {
+        let db = setup_test_db().await;
+
+        let entries = vec![make_entry(
+            LABEL_USER_REGISTER,
+            b"user_pubkey",
+            b"user_signature",
+            1_000_000_000,
+            1,
+        )];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "user_registrations").await,
+            1,
+            "USER_REGISTER should dispatch to user_registrations"
+        );
+    }
+
+    #[tokio::test]
     async fn test_insert_entries_provides_clear_error_context_on_failure() {
         let db = setup_test_db().await;
 

--- a/api/src/database/handlers.rs
+++ b/api/src/database/handlers.rs
@@ -136,3 +136,270 @@ impl Database {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::database::test_helpers::setup_test_db;
+    use crate::database::Database;
+    use crate::database::LedgerEntryData;
+    use dcc_common::{
+        LABEL_CONTRACT_SIGN_REPLY_LEGACY, LABEL_CONTRACT_SIGN_REQUEST_LEGACY,
+        LABEL_NP_CHECK_IN, LABEL_NP_OFFERING_LEGACY,
+        LABEL_NP_PROFILE_LEGACY, LABEL_NP_REGISTER, LABEL_PROV_CHECK_IN, LABEL_PROV_OFFERING_LEGACY,
+        LABEL_PROV_PROFILE_LEGACY, LABEL_PROV_REGISTER, LABEL_REPUTATION_CHANGE, LABEL_USER_REGISTER,
+    };
+
+    fn make_entry(label: &str, key: &[u8], value: &[u8], timestamp: u64, offset: u64) -> LedgerEntryData {
+        LedgerEntryData {
+            label: label.to_string(),
+            key: key.to_vec(),
+            value: value.to_vec(),
+            block_timestamp_ns: timestamp,
+            block_hash: vec![offset as u8; 3],
+            block_offset: offset,
+        }
+    }
+
+    async fn count_rows(db: &Database, table: &str) -> i64 {
+        use sqlx::Row;
+        if table.starts_with("provider_") {
+            let example_pubkey = Database::example_provider_pubkey();
+            let sql = format!(
+                "SELECT COUNT(*) as count FROM {} WHERE pubkey != $1",
+                table
+            );
+            let row = sqlx::query(&sql)
+                .bind(example_pubkey)
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+            row.get("count")
+        } else {
+            let sql = format!("SELECT COUNT(*) as count FROM {}", table);
+            let row = sqlx::query(&sql)
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+            row.get("count")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_legacy_labels_skipped() {
+        let db = setup_test_db().await;
+
+        let legacy_labels = [
+            LABEL_PROV_PROFILE_LEGACY,
+            LABEL_NP_PROFILE_LEGACY,
+            LABEL_PROV_OFFERING_LEGACY,
+            LABEL_NP_OFFERING_LEGACY,
+            LABEL_CONTRACT_SIGN_REQUEST_LEGACY,
+            LABEL_CONTRACT_SIGN_REPLY_LEGACY,
+        ];
+
+        let entries: Vec<LedgerEntryData> = legacy_labels
+            .iter()
+            .enumerate()
+            .map(|(i, label)| make_entry(label, b"legacy_key", b"legacy_value", 1_000_000_000 + i as u64, i as u64))
+            .collect();
+
+        let result = db.insert_entries(entries).await;
+        assert!(result.is_ok(), "Legacy labels should be accepted without error");
+
+        let tables = [
+            "provider_registrations",
+            "provider_check_ins",
+            "user_registrations",
+            "token_transfers",
+            "token_approvals",
+            "reputation_changes",
+            "reputation_aging",
+            "reward_distributions",
+        ];
+        for table in &tables {
+            assert_eq!(
+                count_rows(&db, table).await,
+                0,
+                "Legacy label entries should not insert into {}",
+                table
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_np_register() {
+        let db = setup_test_db().await;
+
+        let entries = vec![make_entry(
+            LABEL_NP_REGISTER,
+            b"np_provider_key",
+            b"np_signature",
+            1_000_000_000,
+            1,
+        )];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_registrations").await,
+            1,
+            "NP_REGISTER should dispatch to provider_registrations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_np_check_in() {
+        let db = setup_test_db().await;
+
+        let payload = dcc_common::CheckInPayload::new("np_check_in".to_string(), vec![1, 2, 3, 4]);
+        let entries = vec![make_entry(
+            LABEL_NP_CHECK_IN,
+            b"np_provider_key",
+            &payload.to_bytes().unwrap(),
+            2_000_000_000,
+            1,
+        )];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_check_ins").await,
+            1,
+            "NP_CHECK_IN should dispatch to provider_check_ins"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_mixed_labels_in_single_batch() {
+        let db = setup_test_db().await;
+
+        let provider_key = b"mixed_batch_provider";
+        let user_key = b"mixed_batch_user";
+        let check_in_payload =
+            dcc_common::CheckInPayload::new("mixed_check_in".to_string(), vec![1, 2, 3, 4]);
+
+        let entries = vec![
+            make_entry(LABEL_PROV_REGISTER, provider_key, b"sig_prov", 1_000_000_000, 1),
+            make_entry(LABEL_USER_REGISTER, user_key, b"sig_user", 1_100_000_000, 2),
+            make_entry(
+                LABEL_PROV_CHECK_IN,
+                provider_key,
+                &check_in_payload.to_bytes().unwrap(),
+                1_200_000_000,
+                3,
+            ),
+        ];
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(count_rows(&db, "provider_registrations").await, 1);
+        assert_eq!(count_rows(&db, "user_registrations").await, 1);
+        assert_eq!(count_rows(&db, "provider_check_ins").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_label_grouping_same_batch() {
+        let db = setup_test_db().await;
+
+        let provider_key = b"group_test_provider";
+        let entries: Vec<LedgerEntryData> = (0..3)
+            .map(|i| {
+                let payload = dcc_common::CheckInPayload::new(
+                    format!("check_{}", i),
+                    vec![i as u8; 4],
+                );
+                make_entry(
+                    LABEL_PROV_CHECK_IN,
+                    provider_key,
+                    &payload.to_bytes().unwrap(),
+                    1_000_000_000 + i * 1_000_000,
+                    i,
+                )
+            })
+            .collect();
+
+        db.insert_entries(entries).await.unwrap();
+
+        assert_eq!(
+            count_rows(&db, "provider_check_ins").await,
+            3,
+            "Multiple entries with same label should all be inserted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_unknown_labels_commit_without_error() {
+        let db = setup_test_db().await;
+
+        let entries = vec![
+            make_entry("TotallyUnknownLabel", b"k1", b"v1", 1_000_000_000, 1),
+            make_entry("AlsoUnknown", b"k2", b"v2", 2_000_000_000, 2),
+        ];
+
+        let result = db.insert_entries(entries).await;
+        assert!(
+            result.is_ok(),
+            "Unknown labels should not cause insert_entries to fail; transaction should still commit"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_malformed_reputation_change_fails_transaction() {
+        let db = setup_test_db().await;
+
+        let provider_key = b"tx_fail_provider";
+        let check_in_payload =
+            dcc_common::CheckInPayload::new("valid_check_in".to_string(), vec![1, 2, 3, 4]);
+
+        let entries = vec![
+            make_entry(LABEL_PROV_REGISTER, provider_key, b"sig", 1_000_000_000, 1),
+            make_entry(
+                LABEL_PROV_CHECK_IN,
+                provider_key,
+                &check_in_payload.to_bytes().unwrap(),
+                1_100_000_000,
+                2,
+            ),
+            make_entry(
+                LABEL_REPUTATION_CHANGE,
+                b"rep_key",
+                b"invalid_borsh_data",
+                1_200_000_000,
+                3,
+            ),
+        ];
+
+        let result = db.insert_entries(entries).await;
+        assert!(result.is_err(), "Malformed borsh data should cause failure");
+
+        assert_eq!(
+            count_rows(&db, "provider_registrations").await,
+            0,
+            "Failed transaction should roll back all inserts"
+        );
+        assert_eq!(
+            count_rows(&db, "provider_check_ins").await,
+            0,
+            "Failed transaction should roll back all inserts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_entries_provides_clear_error_context_on_failure() {
+        let db = setup_test_db().await;
+
+        let entries = vec![make_entry(
+            LABEL_REPUTATION_CHANGE,
+            b"some_key",
+            b"not_valid_borsh",
+            1_000_000_000,
+            1,
+        )];
+
+        let result = db.insert_entries(entries).await;
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("reputation change"),
+            "Error should contain context about which handler failed, got: {}",
+            err_msg
+        );
+    }
+}

--- a/api/src/database/providers/external.rs
+++ b/api/src/database/providers/external.rs
@@ -230,3 +230,167 @@ impl Database {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::database::test_helpers::setup_test_db;
+    use crate::database::LedgerEntryData;
+
+    fn make_entry(label: &str, key: &[u8], value: &[u8], timestamp: u64, offset: u64) -> LedgerEntryData {
+        LedgerEntryData {
+            label: label.to_string(),
+            key: key.to_vec(),
+            value: value.to_vec(),
+            block_timestamp_ns: timestamp,
+            block_hash: vec![offset as u8; 3],
+            block_offset: offset,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_registrations_stores_columns() {
+        let db = setup_test_db().await;
+        let pubkey = b"reg_col_test";
+        let signature = b"test_signature_data";
+
+        let entries = vec![make_entry(
+            "PROV_REGISTER",
+            pubkey,
+            signature,
+            1_000_000_000,
+            1,
+        )];
+
+        let mut tx = db.pool.begin().await.unwrap();
+        db.insert_provider_registrations(&mut tx, &entries)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT pubkey, signature, created_at_ns FROM provider_registrations WHERE pubkey = $1",
+        )
+        .bind(pubkey.as_slice())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+
+        let stored_pubkey: Vec<u8> = row.get("pubkey");
+        let stored_sig: Vec<u8> = row.get("signature");
+        let stored_ts: i64 = row.get("created_at_ns");
+
+        assert_eq!(stored_pubkey, pubkey.as_slice());
+        assert_eq!(stored_sig, signature.as_slice());
+        assert_eq!(stored_ts, 1_000_000_000_i64);
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_registrations_multiple_different_pubkeys() {
+        let db = setup_test_db().await;
+
+        let entries = vec![
+            make_entry("PROV_REGISTER", b"pubkey_aaa", b"sig_a", 1_000_000_000, 1),
+            make_entry("PROV_REGISTER", b"pubkey_bbb", b"sig_b", 2_000_000_000, 2),
+        ];
+
+        let mut tx = db.pool.begin().await.unwrap();
+        db.insert_provider_registrations(&mut tx, &entries)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM provider_registrations WHERE pubkey != $1")
+            .bind(crate::database::Database::example_provider_pubkey())
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_check_ins_stores_memo_and_nonce() {
+        let db = setup_test_db().await;
+        let pubkey = b"checkin_memo_test";
+
+        let payload = dcc_common::CheckInPayload::new("hello_memo".to_string(), vec![0xAA; 64]);
+        let entries = vec![make_entry(
+            "PROV_CHECK_IN",
+            pubkey,
+            &payload.to_bytes().unwrap(),
+            3_000_000_000,
+            1,
+        )];
+
+        let mut tx = db.pool.begin().await.unwrap();
+        db.insert_provider_check_ins(&mut tx, &entries)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT memo, nonce_signature, block_timestamp_ns FROM provider_check_ins WHERE pubkey = $1",
+        )
+        .bind(pubkey.as_slice())
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+
+        let memo: String = row.get("memo");
+        let nonce_sig: Vec<u8> = row.get("nonce_signature");
+        let ts: i64 = row.get("block_timestamp_ns");
+
+        assert_eq!(memo, "hello_memo");
+        assert_eq!(nonce_sig, vec![0xAAu8; 64]);
+        assert_eq!(ts, 3_000_000_000_i64);
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_check_ins_skips_invalid_non_legacy_payload() {
+        let db = setup_test_db().await;
+        let pubkey = b"checkin_skip_test";
+
+        let invalid_payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let entries = vec![make_entry(
+            "PROV_CHECK_IN",
+            pubkey,
+            &invalid_payload,
+            4_000_000_000,
+            1,
+        )];
+
+        let mut tx = db.pool.begin().await.unwrap();
+        db.insert_provider_check_ins(&mut tx, &entries)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM provider_check_ins WHERE pubkey = $1")
+            .bind(pubkey.as_slice())
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "Short invalid payload should be skipped (not 64 bytes, not valid borsh)");
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_check_ins_empty_entries_is_ok() {
+        let db = setup_test_db().await;
+
+        let mut tx = db.pool.begin().await.unwrap();
+        let result = db.insert_provider_check_ins(&mut tx, &[]).await;
+        assert!(result.is_ok());
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_insert_provider_registrations_empty_entries_is_ok() {
+        let db = setup_test_db().await;
+
+        let mut tx = db.pool.begin().await.unwrap();
+        let result = db.insert_provider_registrations(&mut tx, &[]).await;
+        assert!(result.is_ok());
+        tx.commit().await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Adds 14 inline tests for `api/src/database/handlers.rs`, the central ledger entry dispatcher that previously had no test coverage.

**Prep stage (8 tests):**
- Legacy label skipping (6 legacy labels produce no inserts)
- NP_REGISTER dispatch to provider_registrations
- NP_CHECK_IN dispatch to provider_check_ins
- Mixed label batching (PROV_REGISTER + USER_REGISTER + PROV_CHECK_IN)
- Label grouping (3 same-label entries all inserted)
- Unknown labels commit without error
- Malformed reputation change rolls back entire transaction
- Error message provides clear context on failure

**Dev stage (6 additional tests):**
- Empty entries vec early return (Ok)
- PROV_REGISTER dispatch to provider_registrations
- Legacy 64-byte check-in fallback path (external.rs backward compatibility)
- Provider registration upsert (ON CONFLICT DO UPDATE)
- Mixed PROV_REGISTER + NP_REGISTER in same batch dispatches to same handler
- USER_REGISTER dispatch

## Test plan
- All 14 tests pass with `TEST_DATABASE_URL=postgres://test:test@postgres:5432/test cargo nextest run -p api --test-threads=2 -E 'test(database::handlers)'`
- CI will validate full test suite

## Files not covered by this PR (follow-up tickets)
- `providers/external.rs` (insert_provider_registrations, insert_provider_check_ins - tested indirectly via handlers.rs)
- `providers/sla.rs`
- `contracts/provisioning.rs`, `extensions.rs`, `rental.rs`, `payment.rs`, `usage.rs`
- `providers/auto_accept.rs` (tested via providers/tests.rs)

Closes #84