### PR TITLE
docs: agent identity usage + API/service-token future work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,54 @@ node scripts/dc-auth.js seed-contracts
 ```
 - `seed-ux-data` starts a heartbeat daemon to keep the provider online; stop it with `kill $(cat /tmp/dc-keepalive-*.pid)`.
 
+## Acting as an existing provider identity autonomously
+
+decent-cloud has **no API-token / service-token mechanism yet** (see
+`docs/OPEN_ISSUES.md` → "Future work: API key / service token"). Until one exists,
+provider auth = **Ed25519-signed API requests derived from a BIP-39 seed** — there
+is no other path. This section covers how automation (the AI agent, CI, the
+real-deployment e2e harness) acts as an EXISTING provider identity without going
+through the website sign-up flow.
+
+- **Identity store (agent-accessible, age-tier):** the outer
+  `/project/decent-cloud/secrets/shared/env.yaml` (age-SOPS; decrypt with
+  `/project/decent-cloud/secrets/.age-identity`) holds:
+  - `DC_PROD_RESELLER_SEED` — 12-word BIP-39 seed phrase for the prod
+    `hetzner-reseller` account (Ed25519 pubkey `1ed6136d…`).
+  - `DC_PROD_RESELLER_PUBKEY` — the matching Ed25519 pubkey (64 hex chars), for
+    verifying the derivation below produced the right keypair.
+  - Decrypt (value NEVER leaves this command's pipe):
+    ```bash
+    cd /project/decent-cloud && \
+      SOPS_AGE_KEY_FILE=$(pwd)/secrets/.age-identity sops -d secrets/shared/env.yaml
+    ```
+- **To act as the identity:** derive the Ed25519 keypair from the seed **EXACTLY
+  as the website does** (so the derived pubkey matches `DC_PROD_RESELLER_PUBKEY`),
+  then sign each request with the canonical scheme in `common/src/api_auth.rs`
+  (`build_signed_message`: byte-concat `timestamp‖nonce‖METHOD‖/api/v1/…path‖body`,
+  no separators; Ed25519ph signature; context `b"decent-cloud"`; headers
+  `X-Public-Key`/`X-Signature`/`X-Timestamp`/`X-Nonce`). The server verifier is
+  `api/src/auth.rs::verify_request_signature`. **Reuse the derivation + signing
+  code in the real-deployment e2e harness**
+  (`tools/e2e-real-deployments/src/crypto.js`: `deriveIdentity` +
+  `signRequest`) — do NOT re-implement either step. (Today the harness creates a
+  fresh account per run; a small change lets it load `DC_PROD_RESELLER_SEED` from
+  env.yaml and act as the existing `hetzner-reseller` provider: create/manage
+  offerings, run flows, provision/teardown.)
+- **Security constraints (load-bearing):**
+  - The seed is a **MASTER key** (full account control). It lives ONLY in the
+    age-tier `env.yaml` (operator-local outer store — NOT in any public git repo,
+    NOT in the k8s PGP-SOPS secret, NOT in this product repo). NEVER print, echo,
+    log, or commit the seed value.
+  - **Threat model:** `env.yaml` already guards push-capable (`GITHUB_TEST_PAT`)
+    + spend-capable (`HETZNER_API_TOKEN_*`) + Stripe creds under the same age key;
+    a master seed there is consistent with that tier.
+  - When done with a derived keypair, drop in-memory references; NEVER persist a
+    derived private key to disk.
+  - **Future:** a non-custodial API/service-token feature (see
+    `docs/OPEN_ISSUES.md` future-work) will let automation auth with a scoped,
+    revocable token so the master seed can stay fully offline.
+
 ## PROJECT RULES
 - **MINIMIZE CLOUD SPENDING**: When testing against paid cloud providers (Hetzner, AWS, etc.), ALWAYS use the cheapest possible server type (e.g., `cx22` on Hetzner), ALWAYS delete resources immediately after verification, and NEVER leave VMs running unattended. Every test VM must be cleaned up in the same session it was created.
 - Adjust and extend existing code instead of creating parallel implementations. Before you start coding, PLAN how existing code can be adjusted in the most concise way.

--- a/docs/OPEN_ISSUES.md
+++ b/docs/OPEN_ISSUES.md
@@ -13,6 +13,34 @@ gh issue list --repo decent-stuff/decent-cloud --state open --json number,title,
 - **In scope**: labeled `launch`, `stripe`, or `decent-agents` WITHOUT `deferred-post-launch`.
 - **Deferred**: labeled `deferred-post-launch`. Valid but parked until ≥20 paying customers.
 
+## Future work
+
+Proposals not yet filed as GitHub issues — distinct from the open/deferred tables
+above. Each is a forward-looking design note for a future session.
+
+### Future work: API key / service token (non-custodial automation auth)
+
+- **Problem:** provider auth today requires the Ed25519 master key (derived from
+  the BIP-39 seed). Automation (CI, the AI agent, the real-deployment e2e
+  harness) must therefore hold the master seed — a root-credential exposure. As a
+  pragmatic unblock, the prod `hetzner-reseller` seed is currently stored in the
+  agent-accessible age-tier `secrets/shared/env.yaml` (operator-local outer store,
+  NOT in any public repo) as `DC_PROD_RESELLER_SEED` / `DC_PROD_RESELLER_PUBKEY`.
+- **Proposal:** add a non-custodial "API key / service token" feature: a provider
+  mints one or more scoped, revocable tokens (stored hashed in the DB, mirroring
+  the `cloud_accounts.credentials_encrypted` pattern) that authenticate API
+  requests WITHOUT the master key. Automation authenticates with the token; the
+  master seed stays fully offline.
+- **Why:** aligns with `docs/PRODUCT-DIRECTION.md` (operator reselling at scale;
+  programmatic provider management); removes root-credential exposure from
+  automation; enables per-token scoping (e.g. read-only, offerings-only) +
+  rotation without identity churn. The signing scheme (`api/src/auth.rs` +
+  `common/src/api_auth.rs`) would gain a token-auth path alongside the Ed25519
+  path.
+- **Status:** Proposed (future session). Not blocking — the env.yaml-seed path
+  works today (see `repo/AGENTS.md` → "Acting as an existing provider identity
+  autonomously").
+
 ## Infrastructure — staging → k8s (`dc-stage`) consolidation — PoC VERIFIED, cutover pending
 
 **Status (2026-08-03):** Tracks 1+2+3 done autonomously; **Track 2 PoC VERIFIED LIVE**


### PR DESCRIPTION
Doc-only (no code, no secrets). Two additive documentation changes:

- **`AGENTS.md`** — new section "Acting as an existing provider identity autonomously": how automation (the AI agent, CI, the real-deployment e2e harness) authenticates as an EXISTING provider via the env.yaml-resident BIP-39 seed (`DC_PROD_RESELLER_SEED` / `DC_PROD_RESELLER_PUBKEY`), reusing the derivation + signing code in `tools/e2e-real-deployments/src/crypto.js` and the canonical scheme in `common/src/api_auth.rs` (`api/src/auth.rs` verifier). Includes the load-bearing security constraints (master-seed handling, threat model).
- **`docs/OPEN_ISSUES.md`** — new "Future work" subsection proposing a non-custodial API key / service-token feature so automation can auth with a scoped, revocable token (stored hashed, mirroring `cloud_accounts.credentials_encrypted`) instead of the master seed, keeping the seed fully offline.

No code changed. No secrets committed (only the `1ed6136d…` pubkey prefix + var names; the seed value / full pubkey are never written). Branch based on latest `main`.