### PR TITLE
feat(dc-secrets): add operator gpg recipient to all SOPS stores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,13 @@ repo/
   then add its name + source to `docs/CREDENTIALS.md`.
 - `scripts/dc-secrets` reads whatever `$DC_SECRETS_DIR` points at — the committed
   `repo/secrets/shared/*.yaml` (common/dev/play) AND the operator-local outer
-  `/project/decent-cloud/secrets/shared/{env,gh}.yaml`. Full manifest, store
-  layout, and the k8s counterpart (`third_party/k8s/scripts/manage-secrets.py`)
-  are in `docs/CREDENTIALS.md`. Never paste, echo, log, or commit a value.
+  `/project/decent-cloud/secrets/shared/{env,gh}.yaml`. Every store encrypts to
+  **both** the agent `age` key (agent decrypts via `$SOPS_AGE_KEY_FILE`) AND the
+  operator `gpg` key `FA5814CF1935EE80C454C9F1660DCCF069EC9176` (operator decrypts
+  via their gpg keyring); override the pgp recipient with `DC_SOPS_PGP_RECIPIENT`
+  + `sops updatekeys`. Full manifest, store layout, and the k8s counterpart
+  (`third_party/k8s/scripts/manage-secrets.py`) are in `docs/CREDENTIALS.md`.
+  Never paste, echo, log, or commit a value.
 
 ## MANDATORY WORKFLOW (NON-NEGOTIABLE)
 

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -2,9 +2,10 @@
 
 > **RULE (non-negotiable): NEVER ask the user for a credential before checking
 > this document AND running `scripts/dc-secrets list`.** Credentials already
-> persist — SOPS-sealed with the `age` backend (key resolved from
-> `$SOPS_AGE_KEY_FILE` / `$SOPS_AGE_KEY`, or the repo `.age-identity`), and a
-> working subset is additionally injected as env vars each session. Re-asking
+> persist — SOPS-sealed to **both** the agent `age` key and the operator `gpg`
+> key (age key resolved from `$SOPS_AGE_KEY_FILE` / `$SOPS_AGE_KEY`, or the repo
+> `.age-identity`; operator key resolved from the operator's gpg keyring), and
+> a working subset is additionally injected as env vars each session. Re-asking
 > wastes a round-trip and erodes trust. This file lists every credential **NAME**
 > and where it lives; it contains **no values**.
 
@@ -107,6 +108,29 @@ age-key resolution priority: `SOPS_AGE_KEY` → `SOPS_AGE_KEY_FILE` →
 `secrets/.age-identity`. A fresh clone/sandbox has no `.age-identity`; it MUST
 receive the canonical key via one of the two env vars (see
 `agent/docs/secrets.md`). Without it the committed SOPS files cannot decrypt.
+
+### Recipients (agent age key + operator gpg key)
+
+**Every secret store encrypts to BOTH recipients**, so the agent and the operator
+can each decrypt a file independently:
+
+- **agent age key** `age1vdj457g4pyp7u5834sypdt3ys3gum939wwwggqz3jch8aes9lstsh5y9mr`
+  — the agent decrypts via age (`sops -d <file>` with `$SOPS_AGE_KEY_FILE` /
+  `$SOPS_AGE_KEY` set). No gpg keyring needed.
+- **operator gpg key** fingerprint `FA5814CF1935EE80C454C9F1660DCCF069EC9176`
+  (`Saša Tomić <sasa.gpg@kalaj.org>`) — the operator decrypts via their own gpg
+  keyring: `sops -d <file>` with **no** age env var set (sops then falls back to
+  gpg). No agent age key needed.
+
+Both recipients are written into every `.sops.yaml` `creation_rule` by
+`dc-secrets` (the `age:` and `pgp:` lines). To rotate or **add a NEW operator gpg
+key**, set `DC_SOPS_PGP_RECIPIENT=<fingerprint>` (it overrides the default) and
+re-wrap the existing data keys without touching values:
+
+```bash
+DC_SOPS_PGP_RECIPIENT=<new-fingerprint> scripts/dc-secrets init   # regenerate .sops.yaml
+sops updatekeys --yes <file>        # per file, run from the store dir (sops finds .sops.yaml from CWD)
+```
 
 ### k8s counterpart
 

--- a/scripts/dc-secrets
+++ b/scripts/dc-secrets
@@ -3,10 +3,14 @@
 # requires-python = ">=3.10"
 # dependencies = ["pyyaml"]
 # ///
-"""dc-secrets: credential store using SOPS (age backend) with flock concurrency.
+"""dc-secrets: credential store using SOPS (age + operator-gpg recipients) with flock concurrency.
 
 Single source of truth for all credentials. SOPS files are git-committable
 (keys visible, values encrypted). Designed for multi-agent Docker environments.
+
+Every store encrypts to BOTH the agent age key (agent decrypts via
+``$SOPS_AGE_KEY_FILE`` / ``$SOPS_AGE_KEY``) AND the operator gpg key (the
+operator decrypts via their gpg keyring) so each can decrypt independently.
 
 Behavioural spec: 1:1 port of the previous bash implementation. Output formats,
 env-var resolution, file layout and error messages are preserved verbatim because
@@ -35,6 +39,23 @@ SOPS_CONFIG = os.path.join(SECRETS_DIR, ".sops.yaml")
 LOCKS_DIR = os.path.join(SECRETS_DIR, ".locks")
 
 _LOCK_TIMEOUT = 10  # seconds, mirrors `flock -w 10`
+
+# Every secret store encrypts to BOTH the agent age key (the agent decrypts via
+# $SOPS_AGE_KEY_FILE / $SOPS_AGE_KEY) AND the operator gpg key (the operator
+# decrypts via their gpg keyring, no env needed) so each can decrypt a file
+# independently. Override the pgp recipient with DC_SOPS_PGP_RECIPIENT (e.g. to
+# add a NEW operator gpg key, then re-encrypt via `sops updateencrypted`); set it
+# empty to emit an age-only rule (used by hermetic tests / key-less stores).
+DEFAULT_PGP_RECIPIENT = "FA5814CF1935EE80C454C9F1660DCCF069EC9176"
+
+
+def pgp_recipient() -> str | None:
+    """Return the operator gpg recipient for ``.sops.yaml`` creation rules.
+
+    Sourced from ``DC_SOPS_PGP_RECIPIENT`` (default: the operator fingerprint).
+    Returns ``None`` when the var is set empty (opt out of a pgp recipient).
+    """
+    return os.environ.get("DC_SOPS_PGP_RECIPIENT", DEFAULT_PGP_RECIPIENT) or None
 
 
 def die(msg: str) -> None:
@@ -112,13 +133,23 @@ def derive_pubkey(identity_file: str | None = None) -> str | None:
 
 
 def ensure_sops_config(identity_file: str | None = None) -> None:
-    """Create $SOPS_CONFIG (idempotent) using the resolved identity's public key."""
+    """Create $SOPS_CONFIG (idempotent) using the resolved identity's public key.
+
+    The creation rule encrypts to BOTH the agent age key (the agent decrypts via
+    age) AND the operator gpg key (the operator decrypts via their gpg keyring),
+    so each can decrypt a file independently. The pgp recipient is sourced from
+    :func:`pgp_recipient` (``DC_SOPS_PGP_RECIPIENT``, default operator key).
+    """
     if os.path.isfile(SOPS_CONFIG):
         return
     pubkey = derive_pubkey(identity_file)
     if not pubkey:
         die("could not derive age public key for .sops.yaml")
-    content = f"creation_rules:\n  - path_regex: \\.yaml$\n    age: {pubkey}\n"
+    rules = f"    age: {pubkey}\n"
+    pgp = pgp_recipient()
+    if pgp:
+        rules += f"    pgp: {pgp}\n"
+    content = f"creation_rules:\n  - path_regex: \\.yaml$\n{rules}"
     atomic_write(SOPS_CONFIG, content, mode=0o644)
 
 
@@ -733,6 +764,11 @@ ENVIRONMENT (age key resolution, in priority order):
     SOPS_AGE_KEY            Inline age key material (CI / secret manager)
     SOPS_AGE_KEY_FILE       Path to an age identity file (host bind-mount in a sandbox)
     DC_SECRETS_DIR          Override secrets directory (default: <repo>/secrets)
+    DC_SOPS_PGP_RECIPIENT   Operator gpg recipient added to every .sops.yaml rule
+                           (default: the operator fingerprint). The agent decrypts
+                           via age; the operator via their gpg keyring. Set empty to
+                           emit an age-only rule. Re-encrypt existing files with
+                           `sops updateencrypted <file>` after changing it.
     A fresh clone has no .age-identity; it MUST receive the canonical key via one of the
     two vars above. See agent/docs/secrets.md.
 

--- a/scripts/test-dc-secrets.sh
+++ b/scripts/test-dc-secrets.sh
@@ -9,6 +9,9 @@ export DC_SECRETS_DIR="$TEST_DIR"
 # `init` generates a fresh bootstrap key (and the portable-key tests below control
 # their own key sources explicitly).
 unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE
+# Hermetic: existing checks use age-only stores (no dependency on a gpg key). The
+# dedicated pgp-recipient check below opts back in with a throwaway fingerprint.
+export DC_SOPS_PGP_RECIPIENT=
 DC_SECRETS="$SCRIPT_DIR/dc-secrets"
 
 pass=0; fail=0
@@ -43,6 +46,21 @@ assert_eq "creates hires dir" "true" "$([[ -d "$TEST_DIR/hires" ]] && echo true 
 # Idempotent
 "$DC_SECRETS" init >/dev/null 2>&1
 assert_eq "init idempotent" "0" "$?"
+
+echo "--- sops config: age + operator-gpg recipients ---"
+# DC_SOPS_PGP_RECIPIENT drives the pgp: line; use a throwaway value so the check
+# never couples to the real operator fingerprint.
+pgp_dir=$(mktemp -d); EXTRA_DIRS+=("$pgp_dir")
+DC_SOPS_PGP_RECIPIENT="FAKEFINGERPRINTFORTHISTEST" DC_SECRETS_DIR="$pgp_dir" \
+    "$DC_SECRETS" init >/dev/null 2>&1
+cfg="$pgp_dir/.sops.yaml"
+assert_eq "config has age recipient" "true" "$(grep -Eq '^[[:space:]]*age:' "$cfg" && echo true || echo false)"
+assert_eq "config has pgp recipient" "true" "$(grep -Eq '^[[:space:]]*pgp:' "$cfg" && echo true || echo false)"
+assert_eq "pgp recipient is the env override" "true" "$(grep -q 'pgp: FAKEFINGERPRINTFORTHISTEST' "$cfg" && echo true || echo false)"
+# Opt-out: an empty DC_SOPS_PGP_RECIPIENT yields an age-ONLY rule (no pgp line).
+nogpg_dir=$(mktemp -d); EXTRA_DIRS+=("$nogpg_dir")
+DC_SOPS_PGP_RECIPIENT="" DC_SECRETS_DIR="$nogpg_dir" "$DC_SECRETS" init >/dev/null 2>&1
+assert_eq "empty pgp recipient omits pgp line" "false" "$(grep -Eq '^[[:space:]]*pgp:' "$nogpg_dir/.sops.yaml" && echo true || echo false)"
 
 echo "--- set/get ---"
 "$DC_SECRETS" set shared/test KEY1=val1 KEY2=val2

--- a/scripts/test_dc_secrets.py
+++ b/scripts/test_dc_secrets.py
@@ -29,13 +29,19 @@ MULTILINE = "line1\nline2\nline3"  # no trailing newline (get normalizes trailin
 
 # ─── helpers ───────────────────────────────────────────────────────────────────
 def _base_env(dc_dir: Path) -> dict:
-    """Inherit PATH/HOME (for sops/age/uv) but scrub ambient key sources."""
+    """Inherit PATH/HOME (for sops/age/uv) but scrub ambient key sources.
+
+    DC_SOPS_PGP_RECIPIENT is set empty so existing tests stay HERMETIC and
+    age-only — they neither depend on a gpg key being present nor invoke gpg.
+    The dedicated pgp-recipient test opts back in with a throwaway fingerprint.
+    """
     env = {
         k: v
         for k, v in os.environ.items()
-        if k not in ("SOPS_AGE_KEY", "SOPS_AGE_KEY_FILE", "DC_SECRETS_DIR")
+        if k not in ("SOPS_AGE_KEY", "SOPS_AGE_KEY_FILE", "DC_SECRETS_DIR", "DC_SOPS_PGP_RECIPIENT")
     }
     env["DC_SECRETS_DIR"] = str(dc_dir)
+    env["DC_SOPS_PGP_RECIPIENT"] = ""
     return env
 
 
@@ -64,6 +70,7 @@ def _minimal_env(dc_dir: Path, secrets: dict[str, str] | None = None) -> dict:
         or k.startswith("UV_")  # uv cache dir etc.
     }
     env["DC_SECRETS_DIR"] = str(dc_dir)
+    env["DC_SOPS_PGP_RECIPIENT"] = ""  # hermetic: discovery never needs a gpg key
     if secrets:
         env.update(secrets)
     return env
@@ -145,6 +152,36 @@ def test_init_idempotent(tmp_path):
     assert r.returncode == 0, r.stderr
     # Second init adopts the now-existing repo identity; key unchanged.
     assert (store / ".age-identity").read_text() == before
+
+
+# ─── .sops.yaml: dual age + operator-gpg recipients ────────────────────────────
+def test_sops_config_has_age_and_pgp_recipients(tmp_path):
+    """The generated .sops.yaml creation rule carries BOTH an age: recipient (the
+    agent path) and a pgp: recipient (the operator path), so each can decrypt a
+    file independently. The pgp value is sourced from DC_SOPS_PGP_RECIPIENT; here
+    we set a throwaway fingerprint so the assertion never couples to the real one.
+    """
+    store = tmp_path / "store"
+    fake_fp = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    r = run_dc(["init"], dc_dir=store, env_extra={"DC_SOPS_PGP_RECIPIENT": fake_fp})
+    assert r.returncode == 0, r.stderr
+    cfg = (store / ".sops.yaml").read_text()
+    assert "creation_rules:" in cfg
+    assert re.search(r"(?m)^\s+age:\s+\S+", cfg), "age recipient line missing"
+    assert re.search(r"(?m)^\s+pgp:\s+\S+", cfg), "pgp recipient line missing"
+    # pgp recipient equals the env override (NOT coupled to the real fingerprint).
+    assert f"pgp: {fake_fp}" in cfg
+
+
+def test_sops_config_pgp_recipient_opt_out(tmp_path):
+    """Setting DC_SOPS_PGP_RECIPIENT="" emits an age-ONLY rule (no pgp line) — the
+    opt-out path used by hermetic tests / key-less stores."""
+    store = tmp_path / "store"
+    r = run_dc(["init"], dc_dir=store, env_extra={"DC_SOPS_PGP_RECIPIENT": ""})
+    assert r.returncode == 0, r.stderr
+    cfg = (store / ".sops.yaml").read_text()
+    assert re.search(r"(?m)^\s+age:\s+\S+", cfg)
+    assert "pgp:" not in cfg
 
 
 # ─── set / get round-trip ─────────────────────────────────────────────────────

--- a/secrets/.sops.yaml
+++ b/secrets/.sops.yaml
@@ -1,3 +1,4 @@
 creation_rules:
   - path_regex: \.yaml$
     age: age1vdj457g4pyp7u5834sypdt3ys3gum939wwwggqz3jch8aes9lstsh5y9mr
+    pgp: FA5814CF1935EE80C454C9F1660DCCF069EC9176

--- a/secrets/shared/common.yaml
+++ b/secrets/shared/common.yaml
@@ -21,17 +21,33 @@ PROXMOX_SSH: ENC[AES256_GCM,data:gKTdrVgv84eEwRb40Wkl24Lw,iv:ToFlDzg7S0vRti4uWyA
 CF_ACCOUNT_ID: ENC[AES256_GCM,data:sTOxSAPFXuEerwK1Vmy+mfjdBsXOtNkyK4Qn8nz9MJ8=,iv:4CjIPoGVWHgHYaimdFFzGhgnxdEPg6A7T2VHNsagBKM=,tag:yjcVsb6pZPEWFKi+LqbhiQ==,type:str]
 CF_API_TOKEN: ENC[AES256_GCM,data:Z0GDzj11jq++okIkVoclUZaOZXv5VYkPqTb/O17jm5r5Rr/T+UbufFus+yY9EufNWcTM//Q=,iv:DSGnuD1uG/9AhhkPSt42io0qg6IB3G/NAUwsXJJw1S4=,tag:BBAtO0+HiNFGePOIrJg+oA==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1vdj457g4pyp7u5834sypdt3ys3gum939wwwggqz3jch8aes9lstsh5y9mr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4OUdZeDJ4eDN5ZjRZa2t5
-            eHgyV09GUVFQN0hzakJKbzNwcGNHbU5mc2hFCkJqbG9kNDJWYWtFY1NrcHJNdDl2
-            aE91NGZYMU5NQ2xjYXRrZmt4UU0vT00KLS0tIDRUR1ZUTzhmMzNDNUduQTFTSUpt
-            Q2U4bThIcVRodUdnOE9jOXFEbnU2ZHcKfXS/CkAlmQvHuffdtzRvOMg0UPDOZ4Vh
-            koKn5pEQbrUec7f7jF1Kbd+AUCznHVoqlyicqyv2qZdPJongHZSGJA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBMkhqRndCZkdPSVBLVXVE
+            alcxeUJaN2VLOWlmWVhmTitmQ1RKSlNrcjAwCnlOcE9LNzU2NzBDS1lhejk4cmdO
+            L0grczlpWDB0NnRhY3JvVjJZODUvclEKLS0tIGRETEZCVFVraWh4a1EwSUUvTEdv
+            bERhcnNOUXNPOW50MUo3bDZkdjJDK3cKvebZTZaP92Dw84kTDjIcboLbVBQuUcOn
+            zUXt55jOF8Czi24v8xldZeONoRuFSR4JffTddvoY4tf/4W9xITDx/A==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-08-02T11:13:44Z"
     mac: ENC[AES256_GCM,data:PH4YMc3vHFz6XsX6ErWG6HgM2qloUT4uFwzQEg/WyYx6gHylqRACWGFmLb8SN69/RMqFkVSYFoQnSq8jwgYU/J8WQhVLTuNMHJLbhK24KSikOk3GJXEcgu0jfHQlCR+AOsWMrUyvE8Gu0ina+MGOtxgvI+w2IUZhrTd6cxu67fE=,iv:72Tw3da09Ubu/aUeLCIw+fGw5zwLm8Nj7GvRJxaEXsE=,tag:5qIqSmUvpQhmqrDuCTLFWA==,type:str]
+    pgp:
+        - created_at: "2026-08-06T16:54:33Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DOOGGGEOGSlcSAQdADxpGISPBsOda18V/WIAuDZJSa8lTTQZiDj63DTQjCD4w
+            G0qFCjmRyB9zA8tpacRAsLgD79bpDHC1bdpq63Sc/a1oKGQ1bnTn7+BTnIwwg+Gi
+            0l4BnFnLkFMLOZlwsVJ1tcJmIZMAxG4FDc5DZ21RIqcj9evXuOHvl8Vt9cK7EAy7
+            tSLkfGTA7GSzBu2xpnXFqhZB/C6C10wGFn4gWH/a0cLNjo2JD3BB4ygZWO33MDXU
+            =GiK9
+            -----END PGP MESSAGE-----
+          fp: FA5814CF1935EE80C454C9F1660DCCF069EC9176
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/secrets/shared/dev.yaml
+++ b/secrets/shared/dev.yaml
@@ -41,14 +41,25 @@ sops:
         - recipient: age1vdj457g4pyp7u5834sypdt3ys3gum939wwwggqz3jch8aes9lstsh5y9mr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5NHhxejNEb0Myckpya3Ry
-            UGx4RGxaSk1TVnJLeU9tck1JTCtuRWdYUUFNCnMwVDVEOTI1bzVCTy9JVTZ3MC9E
-            UklWYWxWTkV1THFweW9rSURjL2dVcHcKLS0tIExoaDRCMmg2YUNLcHFCYVE3a1NR
-            NVYvcHJvTXkyWGVXWmM0RUg4WWp2cW8K6q6JbrT2RNEkF0tB48YN7UQZFl/+uUFx
-            a4QK0QtibXoCkw73EKMwrua4LaaFlL/AIy5drgHYoCvQEEwe/DUIQA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFRlVIdkgweE9XLzVNVTND
+            R1BtSzhOWlUvOEdpOTRJTml5TmVHMzdtNWhzCk5DeTJQYlRScnF2ejg4SXp2S2hn
+            UDlITHMyYTQ1Tnc5Rmd3eHhEc0JDRDQKLS0tIGlJYUIxaW1jczlxbVJDSEVrTitX
+            a05HQmEyczR4bjRFVUJ6NlhqRzhzY2cKmuoMlFj41wtCbJ8h48uD0yNeTTDttSuW
+            Ieda6qdXiBbcrswjPLPJ0/4h0i1lh+3O1PoNefZ2WfxNlQ77D2B2ag==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-07-29T19:58:42Z"
     mac: ENC[AES256_GCM,data:u14pXbIhKXrKd8J4oQaDXT4WOK52JEbBf3vSLhtkNvZxnFEd+pBF1gDLbmrPl20ps2uaj3pPzlYEraYGLiLSwNisQsQ4U8v7cTdOp86mPdmqbzss1hkJGl8KXlmN3CJTse2ycYs//j4nwdJMD3SNHeKgObi1eRoQZn6o2clWrmw=,iv:yPhepw9MqVLniteIsmnWW42Rg22HFNAlRRcg7Khttdw=,tag:R4rvznEy4ST4SbvLoM3JuA==,type:str]
-    pgp: []
+    pgp:
+        - created_at: "2026-08-06T16:55:08Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DOOGGGEOGSlcSAQdAQHSDq5Z6QAKOvqaaB2X5QBt6fcOuyOZ1HJ2yEiOZFjYw
+            3TNZw3PFOSGb1Rq0e5rVTQXS3zgb0ej4qkw3oTCVVSnZiQP8XhD3ssMN+34kXEAX
+            0l4BNhI51T+Xmc55GkWFekKKX1h9HFhTCWCIxYuRmB2wnEjHefUz1FcuWr0mO0B6
+            QN9yznL1jqGIRa3F+/Q25bgRXyhOraufsy/NKNwquoglpWtN73pokw16q1P/OxrZ
+            =cc2c
+            -----END PGP MESSAGE-----
+          fp: FA5814CF1935EE80C454C9F1660DCCF069EC9176
     unencrypted_suffix: _unencrypted
     version: 3.9.4

--- a/secrets/shared/play.yaml
+++ b/secrets/shared/play.yaml
@@ -20,14 +20,25 @@ sops:
         - recipient: age1vdj457g4pyp7u5834sypdt3ys3gum939wwwggqz3jch8aes9lstsh5y9mr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHR3pkTFRockI2eG9sL21L
-            RU9IV3Q2WFhDNCthSHVMKzZSd1FiNGtRbUFJCmU5ZnRUMlFhVVBzYTRyNyt5N2Ey
-            VWpmM2RJYUdkNUNocFg2WW1VZjlGWEEKLS0tIE1nSVowVm51Z1F4YlgxM3VsWFlG
-            endpcklzV0dWVmwwRkdqaEI5c0pmaVEK88Vwnrsl2UJg1aRKMsLRjdTUJEpfJ/IX
-            alJgVialCgeUHS4E/chujShC4hWhn30JR7ZVEx0ZJAaviYM8v6AqEg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuUWZ4NGp6ZmtnMXM3QS9O
+            OUtjMGFaNUVvZ2VFVkljVzRVeS95bno0U2pVCjJRanNLbDh6R1NRVVE1UEZXZGow
+            a2lwcy9QVWdVNGlqbWg1ZEM1UjRBalUKLS0tIG03Z29qdkNvM0tWNnhkVEVZL3dx
+            N01uN2QyMDA5bEduczlPQ0QyN1Ivb3MKSSR9dSMhrhGrXvKWa3HSUZ0UGGdmCmk8
+            SPt1OeWsutwSYohZWBD8CcXNFxt0SzK8M3w/Q/nYc++HCMc0lQx6uw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-07-29T19:58:42Z"
     mac: ENC[AES256_GCM,data:rEluBJ9dbSbGYXqWsZcurQ+LUzGl4CizxnZ2nDivFK9jrnBkgK/pYrZ99KGdUvGr6Tmme9/q/MriTjcLQeziVi+qGV+bqsiXXe5hjYMlaCZAqfHrGvdthfCsoX3b0cVyIjqvU+1VS6GpO0DtBavz1eFhmyi1TNslZAGwoEV5VXU=,iv:9bkphrAH1iS7ugqc3ha4WcezmiA0aXDvuFraECAiDNA=,tag:ZqYKm4OJp9sopqvX7GKrog==,type:str]
-    pgp: []
+    pgp:
+        - created_at: "2026-08-06T16:55:08Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DOOGGGEOGSlcSAQdATzZ1DdqG/wgpIsE6aBqLr6Y3/LVtzmT8fxsBy5EF9B4w
+            Ji401URS708RK6/ZJbAAd9PEPQ73ngupFWK4stRopTAUm3f41k+iTveMhvKRVNUj
+            0l4B/dTmDj7dlyZu0q+nBxJJBF0lqZuMBUeWWoE+ACUq2naW7E+y21WA28qfB+jL
+            1Ko8DgaSGutlCwkpuCxn+zgCKAkbgq01asZGIIlIol+mWFn2GaQ/rsO/iNRpUGYv
+            =7bKq
+            -----END PGP MESSAGE-----
+          fp: FA5814CF1935EE80C454C9F1660DCCF069EC9176
     unencrypted_suffix: _unencrypted
     version: 3.9.4


### PR DESCRIPTION
User directive: *add my gpg pubkey, and remember to add it to every secret store in the future.*

Root cause the user hit: `sops -d secrets/shared/env.yaml` failed with `no identity matched any of the recipients` — every SOPS file was encrypted to the **agent age key only** (no gpg recipient), so a human with a gpg keyring but no `SOPS_AGE_KEY_FILE` could not decrypt.

Fix:
- `scripts/dc-secrets` now emits BOTH `age:` AND `pgp:` recipients in `.sops.yaml`. Operator gpg fingerprint via env `DC_SOPS_PGP_RECIPIENT` (default `FA5814CF1935EE80C454C9F1660DCCF069EC9176` = Saša Tomić's key; override or set empty for age-only).
- Re-encrypted all secret files via `sops updatekeys --yes` (data-key re-wrap only; values byte-identical, MAC preserved): `repo/secrets/shared/{common,dev,play}.yaml`, `secrets/shared/gh.yaml`, `secrets/hires/*.yaml`, both `.sops.yaml`. (`secrets/shared/env.yaml` re-encrypted in place but left uncommitted — carries operator WIP; it already decrypts with the gpg key locally.)
- Now any human holding the operator gpg private key can `sops -d <any secret file>` with NO env var; the agent keeps using age. Future `dc-secrets set` always encrypts to both.
- Tests: pytest 41, bash 58 (green); new regression that `.sops.yaml` carries age+pgp.

Note: committed fingerprint `FA5814CF...` is the key actually present in the env for `sasa.gpg@kalaj.org` (primary [SC] ed25519; sops auto-uses the [E] subkey for encryption).