### PR TITLE
fix(hetzner): P0 cloud-resell provisioning — server deserialize + cleanup

### DIFF
--- a/api/src/cloud/hetzner.rs
+++ b/api/src/cloud/hetzner.rs
@@ -122,7 +122,12 @@ struct HetznerServer {
     status: String,
     public_net: HetznerPublicNet,
     server_type: HetznerServerTypeRef,
-    datacenter: HetznerDatacenter,
+    // Hetzner's server object exposes a top-level `location` (e.g. {name:"nbg1",...}),
+    // NOT `datacenter` (verified against the live API: GET /v1/servers returns
+    // `location`, never `datacenter`). Requiring `datacenter` made every server
+    // response fail to deserialize with `missing field 'datacenter'` — the master
+    // root cause of cloud-resell provisioning silently failing.
+    location: HetznerLocationRef,
     image: Option<HetznerImageRef>,
     created: String,
 }
@@ -140,13 +145,6 @@ struct HetznerIpv4 {
 #[derive(Debug, Deserialize)]
 struct HetznerServerTypeRef {
     name: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct HetznerDatacenter {
-    #[allow(dead_code)]
-    name: String,
-    location: HetznerLocationRef,
 }
 
 #[derive(Debug, Deserialize)]
@@ -382,7 +380,7 @@ impl HetznerBackend {
             status,
             public_ip: Some(s.public_net.ipv4.ip),
             server_type: s.server_type.name,
-            location: s.datacenter.location.name,
+            location: s.location.name,
             image: s.image.map(|i| i.name).unwrap_or_default(),
             created_at,
         }
@@ -628,32 +626,65 @@ impl CloudBackend for HetznerBackend {
             return Err(self.handle_error(server_response).await);
         }
 
-        let server_data: ServerResponse = server_response.json().await?;
-        let mut server = self.convert_server(server_data.server);
+        // POST /servers returned 2xx — a VM now exists on Hetzner. ANY failure
+        // from here (parse error, status-poll failure, SSH-unreachable) must
+        // clean up BOTH the created VM and the SSH key, otherwise we orphan real
+        // resources (this is what stranded VM 159722362 and leaked SSH keys: the
+        // serde parse error skipped cleanup entirely). Extract the VM id from the
+        // raw body first so even a deserialize error (schema drift like the old
+        // `datacenter` bug) can still delete the VM.
+        let body = server_response
+            .text()
+            .await
+            .context("Failed to read create-server response body")?;
+        let created_server_id: Option<String> = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("server")?.get("id")?.as_i64())
+            .map(|id| id.to_string());
 
-        let mut retries = 0;
-        while server.status == ServerStatus::Provisioning && retries < 60 {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            server = self.get_server(&server.id).await?;
-            retries += 1;
+        let provisioned = async {
+            let server_data: ServerResponse =
+                serde_json::from_str(&body).context("Failed to deserialize create-server response")?;
+            let mut server = self.convert_server(server_data.server);
+
+            let mut retries = 0;
+            while server.status == ServerStatus::Provisioning && retries < 60 {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                server = self.get_server(&server.id).await?;
+                retries += 1;
+            }
+
+            if server.status != ServerStatus::Running {
+                anyhow::bail!("Server failed to reach running state: {:?}", server.status);
+            }
+
+            if let Some(ref ip) = server.public_ip {
+                if !self.wait_for_ssh_reachable(ip, 120).await? {
+                    anyhow::bail!("SSH port not reachable after 120s");
+                }
+            }
+
+            Ok::<Server, anyhow::Error>(server)
         }
+        .await;
 
-        if server.status != ServerStatus::Running {
-            cleanup_server_and_key(self, &server.id, &ssh_key_id.to_string()).await;
-            anyhow::bail!("Server failed to reach running state: {:?}", server.status);
-        }
-
-        if let Some(ref ip) = server.public_ip {
-            if !self.wait_for_ssh_reachable(ip, 120).await? {
-                cleanup_server_and_key(self, &server.id, &ssh_key_id.to_string()).await;
-                anyhow::bail!("SSH port not reachable after 120s");
+        match provisioned {
+            Ok(server) => Ok(ProvisionResult {
+                server,
+                ssh_key_id: Some(ssh_key_id.to_string()),
+            }),
+            Err(e) => {
+                // The VM was created on Hetzner but a post-create step failed.
+                // Delete it (if we know its id) and the SSH key so nothing is
+                // orphaned, then surface the original failure.
+                if let Some(id) = &created_server_id {
+                    cleanup_server_and_key(self, id, &ssh_key_id.to_string()).await;
+                } else {
+                    cleanup_ssh_key(self, &ssh_key_id.to_string()).await;
+                }
+                Err(e)
             }
         }
-
-        Ok(ProvisionResult {
-            server,
-            ssh_key_id: Some(ssh_key_id.to_string()),
-        })
     }
 
     async fn get_server(&self, id: &str) -> anyhow::Result<Server> {
@@ -744,12 +775,15 @@ impl CloudBackend for HetznerBackend {
             .send()
             .await?;
 
-        if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
-            tracing::warn!(
-                "Failed to delete Hetzner SSH key {}: {:?}",
-                id,
-                response.status()
-            );
+        // A missing key is already gone — that's the desired end state, so treat
+        // 404 as success. Any other non-2xx (401/403/5xx) is a real failure that
+        // must surface (never silently ignore failures) — callers decide whether
+        // it's fatal or best-effort.
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        if !response.status().is_success() {
+            return Err(self.handle_error(response).await);
         }
 
         Ok(())
@@ -787,11 +821,8 @@ mod tests {
             server_type: HetznerServerTypeRef {
                 name: "cx23".to_string(),
             },
-            datacenter: HetznerDatacenter {
-                name: "fsn1-dc14".to_string(),
-                location: HetznerLocationRef {
-                    name: "fsn1".to_string(),
-                },
+            location: HetznerLocationRef {
+                name: "fsn1".to_string(),
             },
             image: Some(HetznerImageRef {
                 name: "ubuntu-24.04".to_string(),
@@ -832,6 +863,90 @@ mod tests {
         // Unknown falls to Failed
         let converted = backend.convert_server(make_test_server("exploded"));
         assert_eq!(converted.status, ServerStatus::Failed);
+    }
+
+    /// Regression guard for the P0 cloud-resell provisioning bug.
+    ///
+    /// Hetzner's server object exposes a top-level `location` (e.g.
+    /// `{"name":"nbg1",...}`) and has NO `datacenter` field (verified against
+    /// the live API: GET /v1/servers returns `location`, never `datacenter`).
+    /// Requiring `datacenter` made EVERY server response fail to deserialize
+    /// (`missing field 'datacenter'`), so `create_server` failed ~0.35s AFTER
+    /// the VM was actually created: the VM was orphaned, the contract never
+    /// reached `active`, and cleanup couldn't delete it. This feeds the REAL
+    /// live server shape through `serde_json` and asserts it round-trips.
+    #[test]
+    fn test_hetzner_server_deserializes_real_response() {
+        // Verbatim shape captured from the live Hetzner API (GET /v1/servers/<id>).
+        // Top-level `location`, NO `datacenter`, plus many siblings serde ignores.
+        let server_json = r#"{
+            "id": 159722362,
+            "name": "dc-recipe-abcd1234",
+            "status": "running",
+            "created": "2026-08-06T12:00:00+00:00",
+            "public_net": {
+                "ipv4": {"id": 1, "ip": "203.0.113.10", "blocked": false, "dns_ptr": "host.example"},
+                "ipv6": {"id": 2, "ip": "2a01:4f9::1/64", "blocked": false, "dns_ptr": []},
+                "floating_ips": [],
+                "firewalls": []
+            },
+            "server_type": {"id": 114, "name": "cx23", "description": "CX 23", "cores": 2, "memory": 4.0, "disk": 40, "architecture": "x86", "deprecated": false},
+            "location": {"id": 2, "name": "nbg1", "description": "Nuremberg 1 DC Park 1", "city": "Nuremberg", "country": "DE", "latitude": 49.4521, "longitude": 11.0767, "network_zone": "eu-central"},
+            "image": {"id": 161547269, "type": "system", "name": "ubuntu-24.04", "description": "Ubuntu 24.04", "os_flavor": "ubuntu", "os_version": "24.04", "status": "available", "architecture": "x86", "rapid_deploy": true, "deprecated": null, "deleted": null},
+            "iso": null,
+            "rescue_enabled": false,
+            "locked": false,
+            "backup_window": null,
+            "outgoing_traffic": 0,
+            "ingoing_traffic": 0,
+            "included_traffic": 21990232555520,
+            "primary_disk_size": 40,
+            "protection": {"delete": false, "rebuild": false},
+            "labels": {},
+            "volumes": [],
+            "load_balancers": [],
+            "private_net": [],
+            "placement_group": null
+        }"#;
+        let wrapped = format!("{{\"server\":{server_json}}}");
+
+        // The real shape MUST round-trip. With the buggy `datacenter` field this
+        // returned `missing field 'datacenter'` — the P0 root cause.
+        let resp: ServerResponse = serde_json::from_str(&wrapped)
+            .expect("real Hetzner server JSON must deserialize (location, not datacenter)");
+        let backend = HetznerBackend::new("test_token".to_string()).unwrap();
+        let server = backend.convert_server(resp.server);
+
+        assert_eq!(server.id, "159722362");
+        assert_eq!(server.name, "dc-recipe-abcd1234");
+        assert_eq!(server.status, ServerStatus::Running);
+        assert_eq!(server.public_ip.as_deref(), Some("203.0.113.10"));
+        assert_eq!(server.server_type, "cx23");
+        assert_eq!(server.location, "nbg1");
+        assert_eq!(server.image, "ubuntu-24.04");
+    }
+
+    /// Documents the schema contract that broke before the fix: a server object
+    /// that omits `location` (the old `datacenter`-only fixture shape) MUST fail
+    /// to deserialize, proving `location` is the required field. This is why the
+    /// pre-existing hand-rolled fixtures never caught the P0 — they wrongly
+    /// included `datacenter` and omitted `location`, encoding the bug.
+    #[test]
+    fn test_hetzner_server_requires_location_field() {
+        // Old buggy fixture shape: had `datacenter` but NO top-level `location`.
+        let server_json = r#"{
+            "id": 1, "name": "x", "status": "running", "created": "2026-01-01T00:00:00Z",
+            "public_net": {"ipv4": {"ip": "1.2.3.4"}},
+            "server_type": {"name": "cx23"},
+            "datacenter": {"name": "nbg1-dc14", "location": {"name": "nbg1"}},
+            "image": null
+        }"#;
+        let wrapped = format!("{{\"server\":{server_json}}}");
+        let err = serde_json::from_str::<ServerResponse>(&wrapped).unwrap_err();
+        assert!(
+            err.to_string().contains("missing field `location`"),
+            "server object must require top-level `location`, got: {err}"
+        );
     }
 
     #[test]

--- a/api/src/database/contracts/provisioning.rs
+++ b/api/src/database/contracts/provisioning.rs
@@ -690,8 +690,26 @@ impl Database {
             return Ok(false);
         }
 
-        let offering_db_id: i64 = contract.offering_id.parse().map_err(|_| {
-            anyhow::anyhow!("Invalid offering_id in contract: {}", contract.offering_id)
+        // Contracts store the offering's STRING slug (create_rental_request persists
+        // `offering.offering_id`, NOT the numeric DB id). Resolve the numeric id by
+        // (provider_pubkey, offering_id slug) — parsing the slug as i64 silently
+        // broke cloud provisioning for every offering with a non-numeric slug.
+        let provider_pubkey = hex::decode(&contract.provider_pubkey)
+            .map_err(|_| anyhow::anyhow!("Invalid provider pubkey hex"))?;
+
+        let offering_db_id: i64 = sqlx::query_scalar!(
+            r#"SELECT id as "id!: i64" FROM provider_offerings WHERE pubkey = $1 AND offering_id = $2"#,
+            provider_pubkey,
+            contract.offering_id
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Offering '{}' not found for provider {}",
+                contract.offering_id,
+                contract.provider_pubkey
+            )
         })?;
 
         let offering = self
@@ -703,9 +721,6 @@ impl Database {
             Some(t) => t,
             _ => return Ok(false),
         };
-
-        let provider_pubkey = hex::decode(&contract.provider_pubkey)
-            .map_err(|_| anyhow::anyhow!("Invalid provider pubkey hex"))?;
 
         let (cloud_account_id, server_type, location, image) = match provisioner_type {
             "hetzner" => {

--- a/api/src/database/contracts/tests.rs
+++ b/api/src/database/contracts/tests.rs
@@ -2177,6 +2177,100 @@ async fn test_try_auto_accept_contract_no_rule_means_accept_all() {
     assert!(accepted, "No rule for offering means accept all");
 }
 
+/// `try_trigger_cloud_provisioning` must resolve the offering by the contract's
+/// stored STRING offering_id (slug) + provider pubkey, NOT by parsing the slug as
+/// a numeric DB id. Contracts store the offering *slug* (rental.rs persists
+/// `offering.offering_id`, not the numeric id), so a numeric parse silently
+/// breaks cloud provisioning for every hetzner/vultr offering whose slug is
+/// non-numeric (the normal case). Regression test for the silent
+/// "Cloud provisioning trigger failed: Invalid offering_id in contract: <slug>"
+/// failure observed end-to-end.
+#[tokio::test]
+async fn test_try_trigger_cloud_provisioning_resolves_offering_by_slug() {
+    let db = setup_test_db().await;
+    let provider_pk = vec![7u8; 32];
+    let requester_pk = vec![8u8; 32];
+    let contract_id = vec![9u8; 32];
+
+    // Provider profile + account + a valid Hetzner cloud_account (so the resolver
+    // used by try_trigger_cloud_provisioning finds one for the provider).
+    sqlx::query(
+        "INSERT INTO provider_profiles (pubkey, name, api_version, profile_version, updated_at_ns) VALUES ($1, 'Hetz Provider', 'v1', '1.0', 0)",
+    )
+    .bind(&provider_pk)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    let account = db
+        .create_account("hetz_prov", &provider_pk, "hetz@example.com")
+        .await
+        .unwrap();
+    db.create_cloud_account(
+        &account.id,
+        crate::cloud::types::BackendType::Hetzner,
+        "hetz",
+        "encrypted-creds",
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Offering with a deliberately NON-NUMERIC slug + hetzner provisioner config.
+    let offering_slug = "hetzner-cx23-nbg1";
+    sqlx::query(
+        r#"INSERT INTO provider_offerings (
+            pubkey, offering_id, offer_name, currency, monthly_price, setup_fee,
+            visibility, product_type, billing_interval, stock_status,
+            datacenter_country, datacenter_city, unmetered_bandwidth,
+            provisioner_type, provisioner_config, created_at_ns
+        ) VALUES (
+            $1, $2, 'cx23 @ nbg1', 'eur', 8.0, 0,
+            'public', 'compute', 'monthly', 'in_stock',
+            'DE', 'nbg1', FALSE,
+            'hetzner', '{"server_type":"cx23","location":"nbg1","image":"ubuntu-24.04"}', 0
+        )"#,
+    )
+    .bind(&provider_pk)
+    .bind(offering_slug)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    // Contract in 'accepted' status referencing the offering BY SLUG (this is what
+    // create_rental_request stores: offering.offering_id, the slug).
+    insert_contract_request(
+        &db,
+        &contract_id,
+        &requester_pk,
+        &provider_pk,
+        offering_slug,
+        0,
+        "accepted",
+    )
+    .await;
+
+    // Buggy code parsed the slug as i64 → returned Err → provisioning never fired.
+    let triggered = db
+        .try_trigger_cloud_provisioning(&contract_id)
+        .await
+        .expect("try_trigger_cloud_provisioning must resolve the offering by slug and succeed");
+    assert!(
+        triggered,
+        "should create a pending cloud_resource for the hetzner contract"
+    );
+
+    // A pending cloud_resource must exist for this contract, carrying the resolved
+    // server_type/location/image from the offering's provisioner_config.
+    let pending = db.get_pending_provisioning_resources(10).await.unwrap();
+    let ours = pending
+        .iter()
+        .find(|p| p.contract_id.as_deref() == Some(&contract_id[..]))
+        .expect("a pending cloud_resource should have been created for the contract");
+    assert_eq!(ours.server_type, "cx23");
+    assert_eq!(ours.location, "nbg1");
+    assert_eq!(ours.image, "ubuntu-24.04");
+}
+
 #[tokio::test]
 async fn test_cancel_active_contract_with_prorated_refund() {
     let db = setup_test_db().await;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1595,7 +1595,11 @@ async fn serve_command() -> Result<(), std::io::Error> {
     // Start cloud provisioning service in background
     let cloud_provisioning_interval_secs = parse_env_u64("CLOUD_PROVISIONING_INTERVAL_SECS", 10)?;
 
-    let cloud_termination_interval_secs = parse_env_u64("CLOUD_TERMINATION_INTERVAL_SECS", 60)?;
+    // Termination poll interval matches the provisioning interval (10s) so a
+    // cancel never waits up to a full minute before its VM is deleted. Env-
+    // overridable (CLOUD_TERMINATION_INTERVAL_SECS) for ops tuning. Each cancel
+    // previously paid up to ~60s of orphaned-VM billing before this default.
+    let cloud_termination_interval_secs = parse_env_u64("CLOUD_TERMINATION_INTERVAL_SECS", 10)?;
 
     let db_for_cloud = ctx.database.clone();
     let email_svc_for_cloud = ctx.email_service.clone();

--- a/poc/hetzner-provision-probe.mjs
+++ b/poc/hetzner-provision-probe.mjs
@@ -1,0 +1,269 @@
+// REAL-VM probe: rent a Hetzner cloud-resell offering → measure provisioning →
+// cancel → measure cleanup. Captures per-step timing + Hetzner-side state.
+//
+// SAFETY (MINIMIZE-CLOUD-SPENDING):
+//   - cx23 only (cheapest), nbg1, ubuntu-24.04
+//   - VM is DELETED in finally even on timeout/error
+//   - wrapped externally with `timeout 600 node ...`
+//
+// Path: provider(self) → cloud_account(live token) → offering → self-rent
+// (payment_method=test, no Stripe) → auto-accept (auto_accept_rentals=true) →
+// try_trigger_cloud_provisioning → cloud_resource(provisioning) → provisioning
+// service creates VM → contract active. Then cancel → termination service deletes VM.
+//
+// Usage:
+//   HETZNER_API_TOKEN=... timeout 600 node poc/hetzner-provision-probe.mjs
+
+import { execFileSync } from 'node:child_process';
+import { ed25519ph } from '../website/node_modules/@noble/curves/esm/ed25519.js';
+import { hmac } from '../website/node_modules/@noble/hashes/hmac.js';
+import { sha512 } from '../website/node_modules/@noble/hashes/sha512.js';
+import { generateMnemonic, mnemonicToSeedSync } from '../website/node_modules/bip39/src/index.js';
+
+const API_URL = process.env.API_URL || 'http://localhost:59011';
+const DB_URL = process.env.DATABASE_URL || 'postgres://test:test@postgres:5432/test';
+const HETZNER_TOKEN = process.env.HETZNER_API_TOKEN;
+const SSH_PUBKEY = process.env.SSH_PUBKEY || execFileSync('cat', ['/tmp/dc-probe-key/id_ed25519.pub']).toString().trim();
+const SIGN_CONTEXT = new TextEncoder().encode('decent-cloud');
+
+if (!HETZNER_TOKEN) {
+  console.error('FAIL: HETZNER_API_TOKEN env var is required.');
+  process.exit(2);
+}
+
+const T = () => Date.now(); // epoch ms
+const ts = (t) => new Date(t).toISOString();
+const since = (t0) => `${((T() - t0) / 1000).toFixed(1)}s`;
+
+function bytesToHex(b) { let o = ''; for (const x of b) o += x.toString(16).padStart(2, '0'); return o; }
+function randomHex(n) { const b = Buffer.alloc(n); for (let i = 0; i < n; i++) b[i] = Math.floor(Math.random() * 256); return b.toString('hex'); }
+
+function deriveIdentity(seedPhrase) {
+  const seed = new Uint8Array(mnemonicToSeedSync(seedPhrase, ''));
+  const km = hmac(sha512, 'ed25519 seed', seed);
+  const sk = km.subarray(0, 32);
+  const pk = ed25519ph.getPublicKey(sk);
+  return { secretKey: sk, publicKey: pk, pubkeyHex: bytesToHex(pk) };
+}
+
+function sign(id, method, fullPath, bodyData) {
+  const nonce = crypto.randomUUID();
+  const tNs = (BigInt(Date.now()) * 1_000_000n).toString();
+  let body = '';
+  if (typeof bodyData === 'string') body = bodyData;
+  else if (bodyData != null) body = JSON.stringify(bodyData);
+  const signedPath = `/api/v1${fullPath.split('?')[0]}`;
+  const msg = new TextEncoder().encode(tNs + nonce + method.toUpperCase() + signedPath + body);
+  const sig = ed25519ph.sign(msg, id.secretKey, { context: SIGN_CONTEXT });
+  return { headers: { 'X-Public-Key': id.pubkeyHex, 'X-Signature': bytesToHex(sig), 'X-Timestamp': tNs, 'X-Nonce': nonce, 'Content-Type': 'application/json' }, body };
+}
+
+async function call(id, method, fullPath, bodyData) {
+  const { headers, body } = sign(id, method, fullPath, bodyData);
+  const t0 = T();
+  const res = await fetch(`${API_URL}/api/v1${fullPath}`, { method, headers, body: method === 'GET' ? undefined : body });
+  const text = await res.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* */ }
+  return { status: res.status, json, text, ms: T() - t0 };
+}
+
+function seedAccount(pubkeyHex, username) {
+  const email = `${username}@poc.test`;
+  const aid = randomHex(16), kid = randomHex(16);
+  const sql = `
+    INSERT INTO accounts (id, username, email, email_verified) VALUES (decode('${aid}','hex'), '${username}', '${email}', TRUE);
+    INSERT INTO account_public_keys (id, account_id, public_key) VALUES (decode('${kid}','hex'), decode('${aid}','hex'), decode('${pubkeyHex}','hex'));
+  `;
+  execFileSync('psql', [DB_URL, '--no-psqlrc', '-v', 'ON_ERROR_STOP=1', '-c', sql], { stdio: ['ignore', 'ignore', 'pipe'] });
+  return { aid, username, email };
+}
+
+// Hetzner direct (read-only list + delete fallback) using the SAME token the
+// cloud_account stores (== HETZNER_TOKEN here, so delete should succeed).
+async function hz(method, path) {
+  const res = await fetch(`https://api.hetzner.cloud/v1${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${HETZNER_TOKEN}`, 'Content-Type': 'application/json' },
+  });
+  const text = await res.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* */ }
+  return { status: res.status, json, text };
+}
+
+async function hzFindServerByName(namePrefix) {
+  const { json } = await hz('GET', '/servers');
+  return (json?.servers || []).find((s) => s.name.startsWith(namePrefix)) || null;
+}
+
+// Poll contract status + cloud_resource status + Hetzner server until predicate or timeout.
+async function poll(label, contractIdHex, namePrefix, deadlineMs, pred) {
+  const start = T();
+  let last = null;
+  while (T() < deadlineMs) {
+    const c = await call(identity, 'GET', `/contracts/${contractIdHex}`);
+    const cStatus = c.json?.data?.status;
+    // cloud_resource status via DB-direct (the real state machine)
+    let crStatus = null, crExternal = null;
+    try {
+      const out = execFileSync('psql', [DB_URL, '--no-psqlrc', '-At', '-c',
+        `SELECT status, external_id FROM cloud_resources WHERE contract_id = decode('${contractIdHex}','hex') LIMIT 1`],
+        { encoding: 'utf8' });
+      const [s, e] = out.trim().split('|');
+      crStatus = s; crExternal = e;
+    } catch { /* */ }
+    const srv = await hzFindServerByName(namePrefix);
+    const snap = { cStatus, crStatus, crExternal, hzStatus: srv?.status || null, hzId: srv?.id || null };
+    const key = `${cStatus}|${crStatus}|${snap.hzStatus}`;
+    if (key !== last) {
+      console.log(`  [poll ${label}] +${since(start)} contract=${cStatus} cloud_resource=${crStatus} hz_server=${snap.hzStatus}(id=${snap.hzId}) @ ${ts(T())}`);
+      last = key;
+    }
+    if (pred(snap)) return snap;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  console.log(`  [poll ${label}] TIMEOUT after ${since(start)}`);
+  return null;
+}
+
+let identity;
+
+async function main() {
+  const seedPhrase = generateMnemonic(128);
+  identity = deriveIdentity(seedPhrase);
+  const username = `probe${Date.now().toString().slice(-8)}`;
+  console.log(`\n=== Hetzner provision probe (identity ${identity.pubkeyHex.slice(0, 12)}…) ===`);
+  console.log(`ssh_pubkey: ${SSH_PUBKEY.slice(0, 40)}…`);
+  const account = seedAccount(identity.pubkeyHex, username);
+  console.log(`seeded account ${username}`);
+
+  let cloudAccountId = null, offeringId = null, contractIdHex = null;
+  const timings = {};
+
+  try {
+    // 1. provider onboarding
+    let r = await call(identity, 'PUT', `/providers/${identity.pubkeyHex}/onboarding`, {
+      support_email: `${username}@poc.test`, support_hours: '24/7', support_channels: 'Email',
+      regions: 'Europe', payment_methods: 'Stripe', refund_policy: 'probe', sla_guarantee: 'probe',
+    });
+    if (r.json?.success !== true) throw new Error(`onboarding failed: ${r.status} ${r.text?.slice(0, 160)}`);
+    console.log(`[1] onboarding ok (${r.ms}ms)`);
+
+    // 2. cloud_account (live token validation)
+    timings.tCloudAcctStart = T();
+    r = await call(identity, 'POST', '/cloud-accounts', { backendType: 'hetzner', name: `probe-${Date.now()}`, credentials: HETZNER_TOKEN });
+    if (r.json?.success !== true || r.json?.data?.isValid !== true) throw new Error(`cloud-account failed: ${r.status} ${r.text?.slice(0, 200)}`);
+    cloudAccountId = r.json.data.id;
+    timings.tCloudAcctEnd = T();
+    console.log(`[2] cloud_account ${cloudAccountId} validated isValid=true (${r.ms}ms, ${since(timings.tCloudAcctStart)})`);
+
+    // 3. offering cx23/nbg1/ubuntu-24.04 (NO post_provision_script → isolates status-sync bug)
+    const stamp = Date.now().toString().slice(-8);
+    r = await call(identity, 'POST', `/providers/${identity.pubkeyHex}/offerings`, {
+      offering_id: `probe-cx23-${stamp}`, offer_name: '[probe] cx23 nbg1', description: 'probe',
+      currency: 'eur', monthly_price: 8, setup_fee: 0, visibility: 'public', product_type: 'compute',
+      virtualization_type: 'kvm', billing_interval: 'monthly', billing_unit: 'month', is_subscription: true,
+      subscription_interval_days: 30, stock_status: 'in_stock', processor_cores: 2, memory_amount: '4 GB',
+      total_ssd_capacity: '40 GB', unmetered_bandwidth: false, datacenter_country: 'DE', datacenter_city: 'Nuremberg',
+      operating_systems: 'ubuntu-24.04', is_draft: false, provisioner_type: 'hetzner',
+      provisioner_config: JSON.stringify({ server_type: 'cx23', location: 'nbg1', image: 'ubuntu-24.04' }),
+    });
+    if (r.json?.success !== true) throw new Error(`offering failed: ${r.status} ${r.text?.slice(0, 200)}`);
+    offeringId = r.json.data;
+    console.log(`[3] offering ${offeringId} created (${r.ms}ms)`);
+
+    // 4. enable auto_accept_rentals (DB-direct) so self-rent auto-accepts + triggers cloud provisioning
+    execFileSync('psql', [DB_URL, '--no-psqlrc', '-At', '-c',
+      `UPDATE provider_profiles SET auto_accept_rentals = TRUE WHERE pubkey = decode('${identity.pubkeyHex}','hex')`],
+      { stdio: ['ignore', 'ignore', 'pipe'] });
+    console.log(`[4] auto_accept_rentals=TRUE set`);
+
+    // 5. SELF-RENT (payment_method=test → no Stripe → auto-accept path)
+    timings.tRentStart = T();
+    r = await call(identity, 'POST', '/contracts', {
+      offering_db_id: offeringId, ssh_pubkey: SSH_PUBKEY, payment_method: 'test', duration_hours: 1,
+    });
+    timings.tRentEnd = T();
+    if (r.json?.success !== true) throw new Error(`rent failed: ${r.status} ${r.text?.slice(0, 300)}`);
+    contractIdHex = r.json.data.contractId || r.json.data.contract_id || r.json.data;
+    if (typeof contractIdHex !== 'string') contractIdHex = String(contractIdHex);
+    console.log(`[5] rent ok contract=${contractIdHex} (${r.ms}ms) @ ${ts(timings.tRentStart)}`);
+    timings.tRentReturn = timings.tRentEnd;
+
+    const namePrefix = `dc-recipe-${contractIdHex.slice(0, 12)}`;
+    console.log(`    expected VM name prefix: ${namePrefix}`);
+
+    // 6. PROVISIONING: poll until contract=active (or hz server running + 60s grace)
+    console.log('\n[6] === PROVISIONING PHASE ===');
+    const provDeadline = T() + 360_000; // 6 min hard cap for provisioning
+    const provSnap = await poll('prov', contractIdHex, namePrefix, provDeadline, (s) =>
+      s.cStatus === 'active' || s.cStatus === 'cancelled' || s.cStatus === 'failed');
+    timings.tProvEnd = T();
+    if (provSnap?.cStatus === 'active') {
+      console.log(`>>> CONTRACT REACHED ACTIVE at +${since(timings.tRentStart)} (prov phase ${since(timings.tRentStart)} total)`);
+    } else {
+      console.log(`>>> CONTRACT DID NOT REACH ACTIVE. final=${provSnap?.cStatus} (STUCK-ACCEPTED BUG likely) — waiting 60s grace to observe VM state`);
+      // Observe: is the VM running while contract stays non-active? That's the bug signature.
+      await new Promise((r) => setTimeout(r, 60_000));
+    }
+
+    // Record final provisioning snapshot
+    const fprov = await (async () => { const c = await call(identity,'GET',`/contracts/${contractIdHex}`); const srv = await hzFindServerByName(namePrefix); return { c: c.json?.data?.status, srv: srv ? {id:srv.id,status:srv.status,ip:srv.public_net?.ipv4?.ip,created:srv.created} : null }; })();
+    console.log(`    FINAL prov: contract=${fprov.c} hz_server=${JSON.stringify(fprov.srv)}`);
+    timings.finalProvContract = fprov.c; timings.finalProvServer = fprov.srv;
+
+    // 7. CANCEL + measure cleanup
+    console.log('\n[7] === CANCEL + CLEANUP PHASE ===');
+    timings.tCancelStart = T();
+    r = await call(identity, 'PUT', `/contracts/${contractIdHex}/cancel`, { memo: 'probe cleanup' });
+    timings.tCancelEnd = T();
+    console.log(`[7] cancel returned status=${r.status} success=${r.json?.success} (${r.ms}ms) @ ${ts(timings.tCancelStart)}`);
+    if (r.json?.success !== true) console.log(`    cancel body: ${r.text?.slice(0, 200)}`);
+
+    // Poll until VM is GONE from Hetzner AND cloud_resource=deleted (cleanup complete)
+    const cleanDeadline = T() + 420_000; // 7 min cap for cleanup
+    const cleanSnap = await poll('clean', contractIdHex, namePrefix, cleanDeadline, (s) =>
+      s.hzStatus === null && (s.crStatus === 'deleted' || s.crStatus === 'failed'));
+    timings.tCleanEnd = T();
+    if (cleanSnap && cleanSnap.hzStatus === null) {
+      console.log(`>>> VM GONE + cloud_resource=${cleanSnap.crStatus} at +${since(timings.tCancelStart)} (cleanup ${since(timings.tCancelStart)})`);
+    } else {
+      console.log(`>>> CLEANUP INCOMPLETE after ${since(timings.tCancelStart)}: hz=${cleanSnap?.hzStatus} cr=${cleanSnap?.crStatus}`);
+    }
+    timings.cleanupTotalSec = ((T() - timings.tCancelStart) / 1000).toFixed(1);
+
+    // Summary
+    console.log('\n=== TIMING SUMMARY ===');
+    console.log(JSON.stringify({
+      rent_return_ms: timings.tRentEnd - timings.tRentStart,
+      prov_total_s: timings.tProvEnd ? ((timings.tProvEnd - timings.tRentStart) / 1000).toFixed(1) : null,
+      contract_final_after_prov: timings.finalProvContract,
+      cancel_return_ms: timings.tCancelEnd - timings.tCancelStart,
+      cleanup_total_s: timings.cleanupTotalSec,
+      hz_server_final: timings.finalProvServer,
+    }, null, 2));
+  } finally {
+    console.log('\n[finally] cleanup offering/cloud_account/account + any stranded VM...');
+    // Delete the VM directly on Hetzner if it still exists (defensive; same token → should work)
+    try {
+      if (contractIdHex) {
+        const srv = await hzFindServerByName(`dc-recipe-${contractIdHex.slice(0, 12)}`);
+        if (srv) {
+          console.log(`  stranded VM id=${srv.id} name=${srv.name} — deleting directly`);
+          const d = await hz('DELETE', `/servers/${srv.id}`);
+          console.log(`  direct VM delete: ${d.status}`);
+        }
+      }
+    } catch (e) { console.log(`  VM cleanup error: ${e.message}`); }
+    try { if (offeringId != null) { const r = await call(identity,'DELETE',`/providers/${identity.pubkeyHex}/offerings/${offeringId}`); console.log(`  offering delete: ${r.json?.success ? 'ok' : r.text?.slice(0,80)}`); } } catch (e) {}
+    try { if (cloudAccountId) { const r = await call(identity,'DELETE',`/cloud-accounts/${cloudAccountId}`); console.log(`  cloud_account delete: ${r.json?.success ? 'ok' : r.text?.slice(0,80)}`); } } catch (e) {}
+    try {
+      const safe = username.replace(/'/g, "''");
+      execFileSync('psql', [DB_URL, '--no-psqlrc', '-c',
+        `DELETE FROM provider_onboarding WHERE provider_pubkey = decode('${identity.pubkeyHex}','hex'); DELETE FROM provider_profiles WHERE pubkey = decode('${identity.pubkeyHex}','hex'); DELETE FROM cloud_resources WHERE contract_id IN (SELECT contract_id FROM contract_sign_requests WHERE requester_pubkey = decode('${identity.pubkeyHex}','hex')); DELETE FROM signature_audit WHERE account_id = (SELECT id FROM accounts WHERE username='${safe}'); DELETE FROM contract_sign_requests WHERE requester_pubkey = decode('${identity.pubkeyHex}','hex'); DELETE FROM accounts WHERE username='${safe}';`],
+        { stdio: ['ignore', 'ignore', 'pipe'] });
+      console.log('  account/profile/contracts removed (ok)');
+    } catch (e) { console.log(`  account cleanup error: ${e.message.slice(0,160)}`); }
+  }
+}
+
+main().catch((e) => { console.error('probe threw:', e); process.exit(1); });


### PR DESCRIPTION
## Root cause (one line)

`HetznerServer` required a `datacenter` field that **does not exist** in Hetzner's server object (verified live: `GET /v1/servers` returns a top-level `location`, never `datacenter`) → every `create_server` response failed to deserialize (`missing field 'datacenter'`) ~0.35s **after the VM was actually created** → VM orphaned, contract stuck `accepted`, and cleanup couldn't delete the VM (it saw the `pending-` external_id and skipped `delete_server`).

## Why tests missed it

The hand-rolled fixture wrongly included `datacenter`, encoding the wrong schema — so the deserialize path was never exercised against the real API shape.

## The fix

| # | Fix | Confidence |
|---|-----|-----------|
| 1 | `HetznerServer.datacenter` → `location` (top-level `{name:"nbg1",…}`); `convert_server` reads `s.location.name`; removed dead `HetznerDatacenter`; fixed `make_test_server` to the real schema. | 10/10 |
| 2 | `create_server`: **any** failure after `POST /servers` 2xx (parse / status-poll / SSH-wait) now cleans up **both** the created VM (id extracted from raw body so even a serde error can delete it) **and** the SSH key — previously only the non-2xx branch cleaned up the key. | 10/10 |
| 3 | Don't orphan a created VM when a post-create step fails — guaranteed internal deletion before returning `Err` (this is what stranded VM 159722362). | 8/10 |
| 5 | `delete_ssh_key`: surface non-404 errors instead of warn+`Ok` (project rule: never silently ignore failures); 404 stays `Ok`. | 9/10 |
| 4 | Lower `CLOUD_TERMINATION_INTERVAL_SECS` default 60s→10s (env-overridable) so a cancel never waits up to a minute before its VM is deleted. | 8/10 |
| — | (kept) Resolve offering by **slug** not numeric parse — required for provisioning to trigger at all (separate commit + regression test). | 10/10 |

## Real-VM verification (cx23/nbg1/ubuntu-24.04 — cheapest; deleted in `finally`)

Run against the warm stack with a read-write Hetzner token via `poc/hetzner-provision-probe.mjs`:

- **Provision → `active` in 91.3s** (VM `initializing→starting→running`, then `cloud_resource→running` with the real external_id — no longer stuck on `pending-`).
- **Cancel → VM GONE + `cloud_resource→deleted` in 4.7s** (was: stranded forever).
- **Zero stranded resources** after: 0 probe/recipe VMs, 0 probe SSH keys on the account.

## Test results

- `cargo build -p api` ✅ clean; `cargo clippy --all-targets -p api` ✅ 0 warnings.
- New regression tests RED→GREEN:
  - `test_hetzner_server_deserializes_real_response` (feeds the verbatim live server shape — fails with `missing field 'datacenter'` on old code).
  - `test_hetzner_server_requires_location_field` (a `datacenter`-only object now fails to deserialize).
- `openapi::spec_snapshot::openapi_spec_is_stable` ✅ **unchanged** (internal cloud code, no OpenAPI handlers touched).
- `.sqlx` untouched (no SQL strings changed); `sqlx_cache_check` ✅ single committed source.
- Full `cargo nextest run -p api`: every test that completed passed (the few reported "failures" were only SIGTERMs from the harness timeout killing genuinely slow 400–570s DB tests mid-run — no assertion failures, none in the changed areas).

## Deferred

**Fix 6 (race: cancel vs in-flight provisioning)** — flagged as a follow-up rather than forced. A correct fix must coordinate 3 state-machine writes (status guard in `update_cloud_resource_provisioned` + `mark_cloud_resource_failed`, plus `provision_one` cleaning up the created VM on concurrent-cancel), which the project AGENTS.md routes to human review as a concurrency hazard. I'll file the follow-up issue. The shipped fix fully resolves the reported P0 without it.

## Commits
- `fix(provisioning): resolve offering by slug instead of numeric parse`
- `fix(hetzner): P0 cloud-resell provisioning — real \`location\` field + post-create cleanup`
- `chore(poc): add real-VM Hetzner provision/cleanup probe`