### PR TITLE
feat(ci): add deploy-stage job for continuous staging deploys

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,3 +46,70 @@ jobs:
           node -e 'const{chromium}=require("@playwright/test");chromium.launch().then(b=>b.close()).then(()=>console.log("chromium launch OK")).catch(e=>{console.error("chromium launch FAILED — run [sudo npx playwright install-deps chromium] on the runner:\n"+String(e).split("\n").slice(0,6).join("\n"));process.exit(1)})'
       - run: cargo make website-e2e
 
+  deploy-stage:
+    name: Deploy (stage)
+    needs: [build-test, e2e]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: self-hosted
+    env:
+      # Floating tag ArgoCD Image Updater watches for dc-stage. Same literal for
+      # both images (mirrors cf/deploy.py STAGE_DEFAULT_TAG="stage"). This job
+      # only builds + pushes; it does NOT clone/push any other repo, does NOT
+      # use NUC_K3S_REPO_WRITE, and does NOT run any bump script — ArgoCD Image
+      # Updater picks up :stage in the cluster.
+      TAG: stage
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Build API binaries
+        env:
+          SQLX_OFFLINE: "true"
+        run: cargo build --release --locked --target x86_64-unknown-linux-gnu --bin api-server --bin dc
+
+      - name: Build website
+        env:
+          # Stage VITE config. Only VITE_DECENT_CLOUD_API_URL is stage-specific
+          # (stage-api.decent-cloud.org). Mirrors deploy-prod in release.yml for
+          # the Chatwoot pair + Telegram: the widget renders ONLY when BOTH
+          # Chatwoot vars are set, so an unset pair yields a console-clean bundle
+          # with the widget gated off (see ChatwootWidget.svelte).
+          VITE_DECENT_CLOUD_API_URL: https://stage-api.decent-cloud.org
+          VITE_CHATWOOT_BASE_URL: ${{ vars.CHATWOOT_BASE_URL }}
+          VITE_CHATWOOT_WEBSITE_TOKEN: ${{ secrets.CHATWOOT_WEBSITE_TOKEN }}
+          VITE_TELEGRAM_BOT_USERNAME: DecentCloudBot
+        run: |
+          cd website
+          npm ci
+          npm run build
+
+      - name: Build and push images
+        env:
+          FORGEJO_OWNER: ${{ secrets.FORGEJO_OWNER }}
+          FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+          FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+        run: |
+          # Self-hosted runner: prefer rootless podman (no host/docker access needed);
+          # fall back to docker if that is what is installed. Keep the local cargo cache.
+          CTR="$(command -v podman || command -v docker)"
+          [ -n "$CTR" ] || { echo "ERROR: neither podman nor docker found on runner" >&2; exit 1; }
+          echo "Using container runtime: $CTR ($("$CTR" --version))"
+          echo "$FORGEJO_TOKEN" | "$CTR" login git.kalaj.org -u "$FORGEJO_USER" --password-stdin
+          "$CTR" build -f api/Dockerfile -t git.kalaj.org/${FORGEJO_OWNER}/decent-cloud-api:${TAG} .
+          "$CTR" build -f cf/Dockerfile -t git.kalaj.org/${FORGEJO_OWNER}/decent-cloud-website:${TAG} .
+          "$CTR" push git.kalaj.org/${FORGEJO_OWNER}/decent-cloud-api:${TAG}
+          "$CTR" push git.kalaj.org/${FORGEJO_OWNER}/decent-cloud-website:${TAG}
+


### PR DESCRIPTION
On push to main (after build-test + e2e), build api+website with stage config and push decent-cloud-api:stage + decent-cloud-website:stage to Forgejo. ArgoCD Image Updater (in nuc-k3s) follows the mutable :stage tag and rolls dc-stage. This job only builds+pushes: no nuc-k3s clone, no NUC_K3S_REPO_WRITE, no bump script.