### PR TITLE
docs(creds): remove outer-workspace persona refs from CREDENTIALS.md

### DIFF
--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -54,7 +54,7 @@ YAML with `flock` concurrency; values round-trip byte-identical through pyyaml.
 | `get <path> <key>` | Read **one** credential value to stdout. |
 | `set <path> <key>=<value>...` | Write one or more credentials (flock-protected). |
 | `delete <path> <key>` | Remove one credential. |
-| `export [<env>] [--agent <n>]` | Print credentials as `KEY=value`, layered: `shared/common.yaml` + `shared/<env>.yaml` (+ `agents/<n>` + `hires/<n>` generic overlay). `<env>` ∈ `{common, play, dev, prod}`. Bare `export` is **common-only** (never leaks another env). Last file wins under shell `eval`. **GitHub persona data does NOT live in `hires/`** — it lives as flat namespaced keys in `shared/gh.yaml` (see "GitHub identities" below). |
+| `export [<env>] [--agent <n>]` | Print credentials as `KEY=value`, layered: `shared/common.yaml` + `shared/<env>.yaml` (+ `agents/<n>` + `hires/<n>` generic overlay). `<env>` ∈ `{common, play, dev, prod}`. Bare `export` is **common-only** (never leaks another env). Last file wins under shell `eval`. |
 | `list [<path>]` | No args: **aggregated credential discovery** (names only — see above). With a path: key names within one file. |
 | `import <env-file> <path>` | Import a `.env` file into encrypted storage. |
 | `edit <path>` | Open a SOPS file in `$EDITOR` (decrypt, edit, re-encrypt). |
@@ -84,7 +84,7 @@ the next agent discovers it.
 | Stage deploy (`dev.decent-cloud.org`) | `secrets/shared/dev.yaml` | **yes** (encrypted) | stage |
 | Production | `secrets/shared/prod.yaml` | **yes** (encrypted) | prod |
 | Per-agent overrides | `secrets/agents/<name>.yaml` | yes | overlay |
-| Per-hire overlay (generic) | `secrets/hires/<name>.yaml` | yes | generic overlay only — **GitHub persona data no longer lives here** (consolidated into `shared/gh.yaml` on 2026-08-09; see "GitHub identities" below) |
+| Per-hire overlay (generic) | `secrets/hires/<name>.yaml` | yes | generic per-name overlay only |
 
 **Committed SOPS files** (`common.yaml`, `dev.yaml`, `play.yaml`) live in
 `repo/secrets/shared/` and are tracked in git — SOPS encrypts the values so the
@@ -150,7 +150,7 @@ store.
 - `common.yaml` / `dev.yaml` / `play.yaml` — committed encrypted SOPS file under `repo/secrets/shared/`.
 - `env.yaml` / `gh.yaml` — local-only SOPS file under the operator `$DC_SECRETS_DIR`.
 - `agents/<n>.yaml` — per-agent overlay.
-- `hires/<n>.yaml` — generic per-name overlay (the dc-secrets tool still creates + overlays it). **GitHub persona data no longer lives here**: the 5 personas were consolidated into `gh.yaml` as flat namespaced keys (`<LOGIN_UPPER>_<FIELD>`, e.g. `ANDRIS_K85_GITHUB_PAT`, `RKALEJS79_GITHUB_EMAIL`). See the "GitHub" table below + outer `AGENTS.md` "## GITHUB IDENTITIES".
+- `hires/<n>.yaml` — generic per-name overlay (the dc-secrets tool still creates + overlays it).
 
 **Scope**: `all` (env-agnostic / spans envs) · `dev` (local slim stack) · `stage`
 (`dc-stage` / `dev.decent-cloud.org`) · `prod`.
@@ -260,27 +260,8 @@ store.
 ### GitHub
 
 The legacy bare service tokens (`GITHUB_API_TOKEN`, `GITHUB_TEST_PAT`,
-`GITHUB_PAT`) were removed as unused — they had zero CI/code consumers. GitHub
-access is via the persona PATs described below.
-
-Each persona field is stored as `<LOGIN_UPPER>_<FIELD>` where `LOGIN_UPPER` is the
-gh login uppercased with non-alphanumerics → `_`. Personas + their key prefixes:
-
-| gh login | key prefix | role | PAT health |
-|---|---|---|---|
-| `andris-k85` | `ANDRIS_K85_*` (11 keys) | SoftwareEngineer1 | **valid** |
-| `rkalejs79` | `RKALEJS79_*` (12 keys) | SoftwareEngineer2 | **valid** |
-| `mozols959` | `MOZOLS959_*` (12 keys) | recovery-account | **valid** |
-| `elena-vogt` | `ELENA_VOGT_*` (7 keys) | AutomationExpert | **dead (401)** — operator refresh via `dc-secrets set shared/gh ELENA_VOGT_GITHUB_PAT=...` |
-| `yanliu38` | `YANLIU38_*` (5 keys) | Owner | **dead (401)** — operator refresh via `dc-secrets set shared/gh YANLIU38_GITHUB_PAT=...` |
-
-Example fields per persona: `*_GITHUB_PAT`, `*_GITHUB_USERNAME`, `*_GITHUB_EMAIL`,
-`*_GITHUB_PASSWORD`, `*_DISPLAY_NAME`, `*_ROLE`, `*_CREATED`, `*_NOTES`, plus
-per-provider mailbox keys (`ANDRIS_K85_PROTON_EMAIL`, `RKALEJS79_TUTA_EMAIL`,
-`MOZOLS959_INBOX_LV_EMAIL`, …). Read one with:
-`DC_SECRETS_DIR=/home/sat/projects/decent-cloud/secrets repo/scripts/dc-secrets get shared/gh <KEY>`.
-The full roster, ssh aliases, and the gh-CLI switching procedure live in outer
-`AGENTS.md` "## GITHUB IDENTITIES".
+`GITHUB_PAT`) were removed as unused — they had zero CI/code consumers. CI
+GitHub access uses the repo-only Actions secrets below.
 
 **Repo-only (NOT in env or SOPS)** — these MUST be set in the GitHub repo
 **Settings → Secrets and variables → Actions** for the `release.yml` workflow;


### PR DESCRIPTION
Removes the GitHub-persona block and scattered persona/outer-store references from `docs/CREDENTIALS.md` that violate the inner/outer workspace separation (HARD RULE):

- Outer path `/home/sat/projects/decent-cloud/secrets` (dc-secrets get shared/gh example)
- Outer `AGENTS.md "## GITHUB IDENTITIES"` pointer
- Persona roster table (5 logins + PAT health) — outer-workspace persona data
- Cross-references to outer `shared/gh.yaml` at 3 other sites (export table, store-layout table, hires/ overlay row)

Persona/identity documentation belongs only in the outer workspace (it already lives canonically in outer `AGENTS.md`). The inner repo's CI GitHub access uses repo-only **Actions secrets** (`FORGEJO_OWNER`/`FORGEJO_USER`/`FORGEJO_TOKEN`, `NUC_K3S_REPO_WRITE`, `DC_REPO_WRITE`), which remain documented inline.

HARD RULE self-scan: no `/home/sat/` paths, no outer-store refs, no outer-`AGENTS.md` pointers in any added line. Diff: +5/−24, one file.