### PR TITLE
chore(docs): remove outer-workspace refs from inner repo

### DIFF
--- a/docs/EMAIL_TESTING_GUIDE.md
+++ b/docs/EMAIL_TESTING_GUIDE.md
@@ -40,7 +40,7 @@ mailchannels._domainkey.decent-cloud.org TXT "v=DKIM1; k=rsa; p=<your_public_key
 Test that MailChannels API key is working:
 
 ```bash
-cd /home/sat/projects/decent-cloud
+cd <path-to-decent-cloud>
 cargo run --bin test-email -- --to your@email.com
 ```
 

--- a/docs/offerings-system-prompt.md
+++ b/docs/offerings-system-prompt.md
@@ -480,11 +480,11 @@ We need to design and implement a flexible, generic offerings system that:
 
 ## Current State Analysis Required
 
-### API Layer (`/home/sat/projects/decent-cloud/api/`)
+### API Layer (`api/`)
 
 **Existing Data Model:**
-- `/home/sat/projects/decent-cloud/api/src/database/offerings.rs` - `Offering` struct (48 fields)
-- `/home/sat/projects/decent-cloud/api/migrations/001_original_schema.sql` - Database schema
+- `api/src/database/offerings.rs` - `Offering` struct (48 fields)
+- `api/migrations/001_original_schema.sql` - Database schema
   - `provider_offerings` table (48 columns)
   - Normalized tables: `provider_offerings_payment_methods`, `provider_offerings_features`, `provider_offerings_operating_systems`
 
@@ -503,11 +503,11 @@ We need to design and implement a flexible, generic offerings system that:
 
 **Missing:** No create/update/delete endpoints exist yet
 
-### Website Layer (`/home/sat/projects/decent-cloud/website-svelte/`)
+### Website Layer (`website/`)
 
 **Existing UI:**
-- `/home/sat/projects/decent-cloud/website-svelte/src/routes/dashboard/offerings/+page.svelte` - Provider offerings dashboard (grid view, placeholders for Create/Edit/Disable)
-- `/home/sat/projects/decent-cloud/website-svelte/src/routes/dashboard/marketplace/+page.svelte` - Buyer marketplace (search/filter, grid display)
+- `website/src/routes/dashboard/offerings/+page.svelte` - Provider offerings dashboard (grid view, placeholders for Create/Edit/Disable)
+- `website/src/routes/dashboard/marketplace/+page.svelte` - Buyer marketplace (search/filter, grid display)
 
 **Existing Patterns for Form Components:**
 - `UserProfileEditor.svelte`, `ContactsEditor.svelte`, `SocialsEditor.svelte`, `PublicKeysEditor.svelte`

--- a/docs/specs/2026-04-25-decent-agents-identity-provisioning-spec.md
+++ b/docs/specs/2026-04-25-decent-agents-identity-provisioning-spec.md
@@ -82,11 +82,9 @@ Non-goals (each filed or noted as `deferred-post-launch`):
   `roberts-kalejs`, ...), a HOME under `tools/homes/dc-<slug>/`,
   GitHub PAT and credentials sourced from
   `secrets/hires/<slug>/env.yaml` via SOPS.
-  NOTE (2026-08-09): the per-persona `secrets/hires/<slug>/` files have been
-  consolidated — persona data now lives as flat namespaced keys
-  (`<LOGIN_UPPER>_<FIELD>`, e.g. `ANDRIS_K85_GITHUB_PAT`) in the canonical
-  `secrets/shared/gh.yaml` of the outer store; `hires/` is no longer used for
-  persona storage. See outer `AGENTS.md` "## GITHUB IDENTITIES". Decent Agents
+  NOTE (2026-08-09): persona provisioning has since been consolidated out of
+  this repo into the outer workspace; the per-persona files described above are
+  no longer used for persona storage. This spec is retained for history. Decent Agents
   productizes the slug/HOME/container shape, but replaces persistent
   per-identity PATs with #414 GitHub App installation tokens minted
   per dispatch.

--- a/scripts/test-dc-secrets.sh
+++ b/scripts/test-dc-secrets.sh
@@ -43,9 +43,8 @@ assert_eq "creates sops config" "true" "$([[ -f "$TEST_DIR/.sops.yaml" ]] && ech
 assert_eq "creates shared dir" "true" "$([[ -d "$TEST_DIR/shared" ]] && echo true || echo false)"
 assert_eq "creates agents dir" "true" "$([[ -d "$TEST_DIR/agents" ]] && echo true || echo false)"
 # NOTE: `hires/` is the GENERIC dc-secrets per-name overlay layer (still created
-# by `init`). GitHub persona data no longer lives in `hires/` — it was
-# consolidated into `shared/gh.yaml` as namespaced keys (`<LOGIN_UPPER>_<FIELD>`).
-# This assertion checks the tool's `init` behaviour, not persona storage.
+# by `init`). This assertion checks the tool's `init` behaviour, not any
+# particular storage policy.
 assert_eq "creates hires dir" "true" "$([[ -d "$TEST_DIR/hires" ]] && echo true || echo false)"
 # Idempotent
 "$DC_SECRETS" init >/dev/null 2>&1

--- a/scripts/test_dc_secrets.py
+++ b/scripts/test_dc_secrets.py
@@ -124,11 +124,8 @@ def test_init_creates_store_with_generated_key(tmp_path):
     assert (store / ".sops.yaml").is_file()
     for sub in ("shared", "agents", "hires", ".locks"):
         # NOTE: `hires/` here is the GENERIC dc-secrets per-name overlay layer
-        # (still created by `init` and overlaid by `export --agent`). GitHub
-        # persona data no longer lives in `hires/` — it was consolidated into
-        # `shared/gh.yaml` as flat namespaced keys (see outer AGENTS.md
-        # "## GITHUB IDENTITIES"). This assertion checks tool behaviour, not
-        # persona storage.
+        # (still created by `init` and overlaid by `export --agent`). This
+        # assertion checks tool behaviour, not any particular storage policy.
         assert (store / sub).is_dir()
     assert "Initialized secrets store at" in r.stdout
     assert "Recipient:" in r.stdout
@@ -385,10 +382,8 @@ def test_export_agent_overlays_after_env(tmp_path):
     under shell `eval`. Missing agent/hires files are NOT fatal.
 
     NOTE: `hires/` here is the GENERIC dc-secrets overlay layer exercised by
-    `export --agent <n>` (the tool still supports it). It is NOT GitHub persona
-    data — personas were consolidated into `shared/gh.yaml` as namespaced keys
-    (`<LOGIN_UPPER>_<FIELD>`). This test covers overlay ordering, not persona
-    storage."""
+    `export --agent <n>` (the tool still supports it). This test covers overlay
+    ordering, not any particular storage policy."""
     store = tmp_path / "store"
     init_store(store)
     run_dc(["set", "shared/common", "K=common"], dc_dir=store)


### PR DESCRIPTION
## Summary

Focused doc/test-comment cleanup: the inner repo must contain **zero references
to the outer workspace** in added content. This sweep neutralizes the remaining
outer-workspace references (hardcoded host paths, outer secrets-store file refs,
persona logins, outer `AGENTS.md` pointers) from inner-repo docs and test
comments.

## HARD RULE (binding)

Added lines (`+`) contain NONE of: outer paths (`/home/sat/...`), outer
secrets-store file refs (`shared/gh.yaml`, `secrets/hires/`), outer `AGENTS.md`
pointers, or persona logins. Verified by self-scan — zero matches.

## Sites addressed

1. **`docs/EMAIL_TESTING_GUIDE.md`** — replaced hardcoded absolute outer path
   (`cd /home/sat/...`) with generic `cd <path-to-decent-cloud>`.
2. **`docs/offerings-system-prompt.md`** — replaced stale hardcoded outer paths
   with repo-relative paths (`api/`, `website/`) AND fixed the stale
   `website-svelte/` → `website/` (the dir was renamed; `website-svelte/` no
   longer exists).
3. **`scripts/test_dc_secrets.py`** (two comment blocks) — stripped the
   outer-store/persona narrative (`shared/gh.yaml`, outer `AGENTS.md`) from
   comments/docstrings; kept the tests' intent (overlay-layer behaviour). Test
   assertions unchanged.
4. **`scripts/test-dc-secrets.sh`** — same: stripped outer-store/persona refs
   from the comment; assertion unchanged.
5. **`docs/specs/2026-04-25-decent-agents-identity-provisioning-spec.md`** —
   neutralized the persona specifics (persona login example, `shared/gh.yaml`,
   outer `AGENTS.md`) inside the dated NOTE of this historical spec; added a
   generic "consolidated out of this repo into the outer workspace; retained for
   history" note. Historical meaning preserved.
6. **`docs/OPEN_ISSUES.md`** (lines ~165, ~286) — examined both. Both are
   accurate historical / self-disclaimed narrative: line 165 is a session-log
   resolved-finding row (the two-store design it references is still documented
   in `repo/AGENTS.md`); line 286 already self-disclaims the seed location as
   "NOT in any public repo" and is material to its security rationale. Per the
   task's discretion ("if purely historical narrative, leave it") these were
   left unchanged — annotating them would contradict the still-present
   `repo/AGENTS.md` two-store section.

## Out of scope (NOT touched)

- `repo/AGENTS.md` credential-architecture section (two-store design — deferred
  to a separate policy decision).
- `docs/plans/*` historical plan docs.
- Test fixtures / hermetic test-data literals (`FOO=bar`, `GITHUB_TEST_PAT`,
  etc.) — left intact.

## Verification

- `python3 -m pytest scripts/test_dc_secrets.py` → **41 passed**
- `bash scripts/test-dc-secrets.sh` → **58 passed, 0 failed**
- HARD RULE self-scan on added lines → **0 matches**

Pure docs/comments cleanup — no production code or test logic changed.