### PR TITLE
fix: wallet loading flash + wallet.rs SQL dedupe + dead accessor cleanup

### DIFF
--- a/api/src/database/wallet.rs
+++ b/api/src/database/wallet.rs
@@ -188,21 +188,24 @@ impl Database {
     }
 
 
-    /// rejecting overdrafts at the row level (`WHERE balance_e9s >= amount`).
-    /// Returns the new balance, or an error if the user has no wallet /
-    /// insufficient funds.
+    /// Debit the wallet and append the audit row, within the caller's
+    /// transaction. Shared by [`debit_wallet_balance`] (a standalone test
+    /// primitive that commits immediately) and [`debit_wallet_for_contract`]
+    /// (prod, which adds the contract-payment update in the same tx so the
+    /// debit + contract mark commit atomically).
     ///
-    /// `amount_e9s` must be strictly positive.
-    #[allow(dead_code)] // wired in Unit 4 (rentals → balance debit)
-    pub async fn debit_wallet_balance(
-        &self,
+    /// Row-level overdraft guard: `WHERE balance_e9s >= amount`. If the wallet
+    /// row is missing or the balance is too low, the UPDATE matches zero rows
+    /// and we return an error — the caller is expected to roll the tx back.
+    /// `entry_type` / `reference` stay bound params (not literals) so this
+    /// INSERT shares one cached query plan with the credit path's INSERT.
+    async fn debit_wallet_in_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         pubkey_hex: &str,
         amount_e9s: i64,
         entry_type: &str,
         reference: Option<&str>,
     ) -> Result<i64> {
-        ensure!(amount_e9s > 0, "debit amount must be positive");
-        let mut tx = self.pool.begin().await?;
         let new_balance = sqlx::query_scalar!(
             r#"UPDATE wallet_balances
                SET balance_e9s = balance_e9s - $2, updated_at = NOW()
@@ -211,9 +214,10 @@ impl Database {
             pubkey_hex,
             amount_e9s,
         )
-        .fetch_optional(&mut *tx)
+        .fetch_optional(&mut **tx)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Insufficient wallet balance for debit"))?;
+
         sqlx::query!(
             r#"INSERT INTO wallet_ledger (pubkey, amount_e9s, balance_after_e9s, entry_type, reference)
                VALUES ($1, $2, $3, $4, $5)"#,
@@ -223,8 +227,30 @@ impl Database {
             entry_type,
             reference,
         )
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
+        Ok(new_balance)
+    }
+
+    /// Debit the wallet (test primitive / generic debit). Begins and commits
+    /// its own transaction. Production rental payments MUST use
+    /// [`debit_wallet_for_contract`] instead, which debits the wallet AND
+    /// marks the contract paid in a single atomic transaction.
+    ///
+    /// Returns the new balance, or an error if the user has no wallet /
+    /// insufficient funds. `amount_e9s` must be strictly positive.
+    #[cfg(test)]
+    pub async fn debit_wallet_balance(
+        &self,
+        pubkey_hex: &str,
+        amount_e9s: i64,
+        entry_type: &str,
+        reference: Option<&str>,
+    ) -> Result<i64> {
+        ensure!(amount_e9s > 0, "debit amount must be positive");
+        let mut tx = self.pool.begin().await?;
+        let new_balance =
+            Self::debit_wallet_in_tx(&mut tx, pubkey_hex, amount_e9s, entry_type, reference).await?;
         tx.commit().await?;
         Ok(new_balance)
     }
@@ -247,31 +273,16 @@ impl Database {
         ensure!(amount_e9s > 0, "debit amount must be positive");
         let mut tx = self.pool.begin().await?;
 
-        // Debit wallet row-level (rejects overdraft via WHERE balance >= amount).
-        let new_balance = sqlx::query_scalar!(
-            r#"UPDATE wallet_balances
-               SET balance_e9s = balance_e9s - $2, updated_at = NOW()
-               WHERE pubkey = $1 AND balance_e9s >= $2
-               RETURNING balance_e9s as "balance_e9s!: i64""#,
+        // Debit wallet + append ledger row (shared with debit_wallet_balance).
+        // The contract id hex is the ledger reference for this rental debit.
+        let contract_id_hex = hex::encode(contract_id);
+        Self::debit_wallet_in_tx(
+            &mut tx,
             requester_pubkey_hex,
             amount_e9s,
+            "rental_debit",
+            Some(&contract_id_hex),
         )
-        .fetch_optional(&mut *tx)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Insufficient wallet balance"))?;
-
-        let contract_id_hex = hex::encode(contract_id);
-
-        // Append immutable ledger entry (signed negative amount).
-        sqlx::query!(
-            r#"INSERT INTO wallet_ledger (pubkey, amount_e9s, balance_after_e9s, entry_type, reference)
-               VALUES ($1, $2, $3, 'rental_debit', $4)"#,
-            requester_pubkey_hex,
-            -amount_e9s,
-            new_balance,
-            contract_id_hex,
-        )
-        .execute(&mut *tx)
         .await?;
 
         // Mark the contract as paid via wallet (no Stripe session/PI).

--- a/common/src/payment_method.rs
+++ b/common/src/payment_method.rs
@@ -27,20 +27,6 @@ pub enum PaymentMethod {
     Test,
 }
 
-impl PaymentMethod {
-    pub fn is_stripe(&self) -> bool {
-        matches!(self, PaymentMethod::Stripe)
-    }
-
-    pub fn is_wallet(&self) -> bool {
-        matches!(self, PaymentMethod::Wallet)
-    }
-
-    pub fn is_test(&self) -> bool {
-        matches!(self, PaymentMethod::Test)
-    }
-}
-
 impl std::fmt::Display for PaymentMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -104,18 +90,6 @@ pub mod payment_status {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_payment_method_is_stripe() {
-        assert!(PaymentMethod::Stripe.is_stripe());
-        assert!(!PaymentMethod::Test.is_stripe());
-    }
-
-    #[test]
-    fn test_payment_method_is_test() {
-        assert!(PaymentMethod::Test.is_test());
-        assert!(!PaymentMethod::Stripe.is_test());
-    }
 
     #[test]
     fn test_payment_method_from_str_valid() {

--- a/docs/OPEN_ISSUES.md
+++ b/docs/OPEN_ISSUES.md
@@ -28,7 +28,7 @@ gh issue list --repo decent-stuff/decent-cloud --state open --json number,title,
 > ║  until frictionless. This is the PRODUCT NORTH STAR — every session    ║
 > ║  must advance it until there is nothing left to smooth out.            ║
 > ║                                                                        ║
-> ║  **Status (2026-08-11 — BUY FLOW WORKING END-TO-END):** The FULL real     ║
+> ║  **Status (2026-08-11 — MERGED to main, PR #479 `05849932`):** The FULL  ║
 > ║  product flow was tested end-to-end locally: discover → rent → pay →    ║
 > ║  provision → SSH → cancel, against a REAL Hetzner cx23 VM (created     ║
 > ║  ~56s, SSH `root@<ip>` verified, cancelled + deleted, zero orphans).   ║
@@ -37,18 +37,19 @@ gh issue list --repo decent-stuff/decent-cloud --state open --json number,title,
 > ║  branch skipped `try_auto_accept_contract`, so every real buyer's      ║
 > ║  contract was stuck at `requested` forever). Fixed by unifying the      ║
 > ║  auto-accept+fulfillment path for ALL payment methods. TDD-proven by    ║
-> ║  `rent-wallet-auto-accept.spec.ts`. In total this session: 6 backend   ║
-> ║  bugs fixed (wallet-auto-accept, dc-auth cancel method, email-verify    ║
-> ║  dev gate, auto_accept default, direct-SSH instance_details, SSH        ║
-> ║  username root@); 9 UX friction points fixed (rent dialog is now a      ║
-> ║  real accessible keyboard-friendly `<form>` with inline wallet          ║
-> ║  balance; Similar Offerings no longer links to dead offerings; honest   ║
-> ║  stats 1/1/1; dead presets hidden; SLA warmed; provider-name links;    ║
-> ║  dup sort removed); buy flow codified as e2e (wallet-debit math in      ║
-> ║  rent-flow, gated real-Hetzner-provisioning spec, wallet-auto-accept    ║
-> ║  proof). **333/334 e2e pass, 0 deterministic failures** (1 skip = the   ║
-> ║  gated real-VM spec). **REMAINING:** operator sign-off to publish real  ║
-> ║  offerings to PROD (the local path is fully verified). See plan         ║
+> ║  `rent-wallet-auto-accept.spec.ts`. In total: 6 backend bugs fixed      ║
+> ║  (wallet-auto-accept, dc-auth cancel method, email-verify dev gate,     ║
+> ║  auto_accept default, direct-SSH instance_details, SSH username root@); ║
+> ║  9 UX friction points fixed (rent dialog is now a real accessible       ║
+> ║  keyboard-friendly `<form>` with inline wallet balance; Similar         ║
+> ║  Offerings no longer links to dead offerings; honest stats 1/1/1;       ║
+> ║  dead presets hidden; SLA warmed; provider-name links; dup sort        ║
+> ║  removed); buy flow codified as e2e (wallet-debit math in rent-flow,   ║
+> ║  gated real-Hetzner-provisioning spec, wallet-auto-accept proof).       ║
+> ║  **CI GREEN** (Build & Test 2617+577 tests pass, clippy clean; E2E      ║
+> ║  Playwright full suite). Independent review APPROVED (`rkalejs79`).     ║
+> ║  **REMAINING:** operator sign-off to publish real offerings to PROD     ║
+> ║  (the local path is fully verified + merged). See plan                 ║
 > ║  `docs/plans/2026-08-11-marketplace-buy-flow-execution.md`.             ║
 > ║                                                                        ║
 > ║  **No further avoiding is acceptable. This is worked on every session.**  ║
@@ -92,7 +93,7 @@ autonomy level.
 |----------|------|--------|
 | **B1** | **~~Close 4 fixed GH issues~~** | **DONE by operator (2026-08-08).** Pushed + deployed. GH issues to close: #466, #452, #453, #447. |
 | **B2** | **~~#470 auto-merge prerequisite~~** | **DONE (2026-08-10).** PR #470 MERGED; auto-merge + `build-and-test` required-check configured. |
-| **B8** | **Hetzner first-offerings (operator sign-off to spend/launch)** | The product north star. Code 100% ready (direct cloud-backend resell path confirmed + VERIFIED end-to-end this session: rent→provision→SSH→cancel against a real cx23, zero orphans). All credentials ARE present and agent-accessible: `HETZNER_API_TOKEN_DEV` (read-write, outer `shared/env`) + `DC_PROD_RESELLER_SEED` (prod `hetzner-reseller` identity). The autonomous local verification (B8's "an agent *could*") is now DONE — the remaining gate is purely **operator sign-off to go PUBLIC (prod)**: publish real offerings to the prod marketplace + authorize ongoing spend. Plan: `docs/plans/2026-08-03-hetzner-first-offerings.md`; execution log: `docs/plans/2026-08-11-marketplace-buy-flow-execution.md`. |
+| **B8** | **Hetzner first-offerings (operator sign-off to spend/launch)** | The product north star. Code 100% ready + **MERGED to main (PR #479 `05849932`)** — the direct cloud-backend resell path is confirmed + verified end-to-end (rent→provision→SSH→cancel against a real cx23, zero orphans). All credentials ARE present and agent-accessible: `HETZNER_API_TOKEN_DEV` (read-write, outer `shared/env`) + `DC_PROD_RESELLER_SEED` (prod `hetzner-reseller` identity). The autonomous local verification (B8's "an agent *could*") is DONE — the remaining gate is purely **operator sign-off to go PUBLIC (prod)**: publish real offerings to the prod marketplace + authorize ongoing spend. Plan: `docs/plans/2026-08-03-hetzner-first-offerings.md`; execution log: `docs/plans/2026-08-11-marketplace-buy-flow-execution.md`. |
 | **B3** | **~~OP-1 — Redeploy prod~~** | **DONE (2026-08-08).** Prod verified: health 200, environment "prod", Google OAuth enabled, 2 REAL offerings (tada $7/mo + hetzner-reseller $6.82/mo, both USD — demos gone). |
 | **B4** | **~~OP-2 — Redeploy stage~~** | **DONE (2026-08-08).** Stage verified at `stage-api.decent-cloud.org`: health 200, environment "stage", 5 offerings (storage/compute/network, all USD). |
 | **B5** | **~~OP-4 — Complete stage DNS cutover~~** | **DONE (2026-08-08).** `stage-api.decent-cloud.org` resolves + serves 200. Legacy `dev-api.decent-cloud.org` returns 502 (dead, as expected post-cutover). |

--- a/website/src/routes/dashboard/wallet/+page.svelte
+++ b/website/src/routes/dashboard/wallet/+page.svelte
@@ -13,12 +13,10 @@
 		hexEncode,
 		type WalletLedgerEntry,
 	} from "$lib/services/api";
-	import type { IdentityInfo } from "$lib/stores/auth";
+	import { Ed25519KeyIdentity } from "@dfinity/identity";
 
-	let currentIdentity = $state<IdentityInfo | null>(null);
 	let isAuthenticated = $state(false);
 	let unsubscribeAuth: (() => void) | null = null;
-	let unsubscribeIdentity: (() => void) | null = null;
 
 	let balanceE9s = $state<number | null>(null);
 	let ledger = $state<WalletLedgerEntry[]>([]);
@@ -34,30 +32,39 @@
 	const topupStatus = $derived($page.url.searchParams.get("topup"));
 
 	onMount(() => {
+		// Subscribe so we re-fire when authStore.initialize() completes (the
+		// dashboard layout calls it in its own onMount, which races with ours).
+		// Mirrors /dashboard/saved and /dashboard/rentals.
 		unsubscribeAuth = authStore.isAuthenticated.subscribe((isAuth) => {
 			isAuthenticated = isAuth;
-		});
-		unsubscribeIdentity = authStore.currentIdentity.subscribe((value) => {
-			currentIdentity = value;
-			if (value) {
-				loadWallet();
-			}
+			loadWallet();
 		});
 	});
 
 	onDestroy(() => {
 		unsubscribeAuth?.();
-		unsubscribeIdentity?.();
 	});
 
 	async function loadWallet() {
-		if (!currentIdentity?.identity) return;
+		// Distinguish "loading" from "unauthenticated": flip loading off as
+		// soon as we know the user is not signed in, so the spinner block
+		// (rendered independently of the auth block below) doesn't spin
+		// forever for anonymous visitors.
+		if (!isAuthenticated) {
+			loading = false;
+			return;
+		}
+		const signingIdentityInfo = await authStore.getSigningIdentity();
+		if (!signingIdentityInfo || !(signingIdentityInfo.identity instanceof Ed25519KeyIdentity)) {
+			loading = false;
+			return;
+		}
 		loading = true;
 		error = "";
 		try {
-			const pubkeyHex = hexEncode(currentIdentity.publicKeyBytes);
+			const pubkeyHex = hexEncode(signingIdentityInfo.publicKeyBytes);
 			const { headers } = await signRequest(
-				currentIdentity.identity,
+				signingIdentityInfo.identity,
 				"GET",
 				`/api/v1/users/${pubkeyHex}/wallet`,
 			);
@@ -72,7 +79,8 @@
 	}
 
 	async function handleTopup() {
-		if (!currentIdentity?.identity) return;
+		const signingIdentityInfo = await authStore.getSigningIdentity();
+		if (!signingIdentityInfo || !(signingIdentityInfo.identity instanceof Ed25519KeyIdentity)) return;
 		const amount = parseFloat(amountInput);
 		if (isNaN(amount) || amount <= 0) {
 			formError = "Enter a positive amount";
@@ -81,9 +89,9 @@
 		submitting = true;
 		formError = "";
 		try {
-			const pubkeyHex = hexEncode(currentIdentity.publicKeyBytes);
+			const pubkeyHex = hexEncode(signingIdentityInfo.publicKeyBytes);
 			const { headers } = await signRequest(
-				currentIdentity.identity,
+				signingIdentityInfo.identity,
 				"POST",
 				`/api/v1/users/${pubkeyHex}/wallet/topup`,
 			);
@@ -123,18 +131,25 @@
 
 	{#if !isAuthenticated}
 		<AuthRequiredCard />
-	{:else if loading}
+	{:else if error}
+		<div class="card p-4 mb-4 border-l-4 border-error/60 bg-error/10">
+			<p class="text-error text-sm">{error}</p>
+		</div>
+	{/if}
+
+	<!-- Loading and content are a SEPARATE block from the auth/error check above.
+	     This is the /dashboard/saved + /dashboard/rentals pattern: the spinner
+	     always renders while loading=true, even during the initial window before
+	     isAuthenticated settles, so an authed user never sees a bare "Login
+	     Required" flash during async identity derivation. -->
+	{#if loading}
 		<div class="card p-8 text-center">
 			<div class="inline-block w-8 h-8 border-2 border-primary-500/30 border-t-primary-500 animate-spin"></div>
 			<p class="text-neutral-400 mt-3">Loading wallet…</p>
 		</div>
+	{:else if !isAuthenticated}
+		<!-- AuthRequiredCard already rendered above; nothing here -->
 	{:else}
-		{#if error}
-			<div class="card p-4 mb-4 border-l-4 border-error/60 bg-error/10">
-				<p class="text-error text-sm">{error}</p>
-			</div>
-		{/if}
-
 		{#if topupStatus === "success"}
 			<div class="card p-4 mb-4 border-l-4 border-success/60 bg-success/10 flex items-center gap-3">
 				<Icon name="check" size={20} class="text-success" />

--- a/website/tests/e2e/wallet-ui.spec.ts
+++ b/website/tests/e2e/wallet-ui.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures/test-account';
+import { waitForAuthReady } from './fixtures/test-account';
 import { sql, pubkeyHexFromSeed } from './fixtures/seed-helpers';
 
 /**
@@ -29,6 +30,48 @@ test.describe('Wallet UI', () => {
 		// Ledger empty state.
 		await expect(page.locator('h2:has-text("Recent Transactions")')).toBeVisible();
 		await expect(page.locator('text=No transactions yet.')).toBeVisible();
+	});
+
+	// Regression: UX-3. The wallet page used to render "Login Required" alone
+	// during the async identity-derivation window (its single if/else chain
+	// checked !isAuthenticated before loading, so the spinner branch was
+	// unreachable while isAuthenticated was still settling). The fix mirrors
+	// the /dashboard/saved + /dashboard/rentals two-block pattern so the
+	// spinner always renders while loading=true — including in the SSR HTML,
+	// where isAuthenticated is always false (no onMount runs on the server).
+	// Asserting the SSR response contains the spinner is the deterministic
+	// signal: the old code's SSR emitted only "Login Required" with no
+	// "Loading wallet"; the fixed code emits both.
+	test('wallet page SSR includes the loading spinner (no Login Required-only flash)', async ({ page, testAccount }) => {
+		const response = await page.goto('/dashboard/wallet');
+		const html = await response!.text();
+		expect(html).toContain('Loading wallet');
+	});
+
+	// Behavioral guard: during the wallet-fetch loading phase (after auth has
+	// resolved but before the GET returns), the spinner is visible and
+	// "Login Required" is absent. Kept as a regression guard on top of the
+	// SSR assertion above.
+	test('wallet page does not flash "Login Required" during the loading phase', async ({ page, testAccount }) => {
+		// Hold the wallet GET open so loading stays true after auth resolves.
+		let releaseWallet: () => void = () => {};
+		await page.route('**/api/v1/users/*/wallet', async (route) => {
+			await new Promise<void>((resolve) => { releaseWallet = resolve; });
+			await route.continue();
+		});
+
+		await page.goto('/dashboard/wallet');
+
+		// Auth is definitively resolved once the sidebar Logout button appears.
+		await waitForAuthReady(page);
+
+		// Still loading (delayed route): spinner visible, "Login Required" absent.
+		await expect(page.getByText('Loading wallet')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByText('Login Required')).toHaveCount(0);
+
+		// Release the delayed response; content renders normally.
+		releaseWallet();
+		await expect(page.locator('text=Available Balance')).toBeVisible({ timeout: 10000 });
 	});
 
 	// Wait for the balance card — it only renders after loadWallet() resolves


### PR DESCRIPTION
## Summary

Three small, independent code-quality fixes on one branch. Each is its own commit.

### 1. Wallet page "Login Required" flash (UX-3)
`website/src/routes/dashboard/wallet/+page.svelte` used a single `if/else` chain that checked `!isAuthenticated` *before* `loading`. During async identity derivation (before `isAuthenticated` settled), the spinner branch was unreachable, so an authed user briefly saw a bare "Login Required" card. The flash was observable in the **SSR HTML**, which emitted `"Login Required"` with no spinner.

**Fix:** adopt the two-block render pattern from `/dashboard/saved` and `/dashboard/rentals` — auth/error in one block, loading/content in a separate block — so the spinner always renders while `loading=true`, independently of the auth check. Also switched `loadWallet()` to the sibling shape: a single `isAuthenticated.subscribe` + `authStore.getSigningIdentity()`, with an early `loading=false` when unauthenticated so the spinner doesn't spin forever for anonymous visitors.

**Test:** a new SSR-response assertion verifies the loading spinner is present in the server-rendered HTML. This **deterministically fails on the old code** (whose SSR emitted only `"Login Required"`, count 0 for `"Loading wallet"`) and passes on the fixed code (both present). A second behavioral guard delays the wallet GET and asserts `"Login Required"` stays absent through the loading phase.

### 2. `debit_wallet_balance` stale dead-code (verifier finding)
`api/src/database/wallet.rs` — `debit_wallet_balance` carried `#[allow(dead_code)]` with a misleading "wired in Unit 4" comment. Reality: all call sites were inside `mod tests`; prod used `debit_wallet_for_contract`, which **duplicated** the debit SQL inline.

**Fix:** extracted the shared `UPDATE wallet_balances … RETURNING` + `INSERT INTO wallet_ledger …` (with the row-level overdraft guard and signed ledger amount) into a private associated helper `debit_wallet_in_tx(&mut Transaction, …)`. Both callers now route through it:
- `debit_wallet_balance` — test-only wrapper (begin → helper → commit), now `#[cfg(test)]` so it compiles only under `cargo test`/`nextest`. Replaces the stale `#[allow(dead_code)]` with an honest, warning-free gate.
- `debit_wallet_for_contract` (prod) — calls the helper inside its existing transaction, then does the contract payment-status update before commit; money-safe atomicity unchanged.

The INSERT now uses bound `entry_type`/`reference` params in both paths (previously the prod path inlined the `'rental_debit'` literal), so both share one cached sqlx query plan — the same plan the credit path already uses. **No `.sqlx` regen needed** (the parameterized INSERT was already cached).

### 3. Unused `is_wallet()` / `is_stripe()` / `is_test()` accessors (verifier finding)
`common/src/payment_method.rs` — all three accessors had zero non-test callers across the workspace (the codebase compares `PaymentMethod` via `from_str` + raw string equality and the `Display` impl). `is_stripe`/`is_test` were already unused before `is_wallet` was added. Removed all three plus the two tests that only exercised them.

## Verification (all green)

| Gate | Result |
|------|--------|
| `cargo clippy --tests -p api -p dcc-common` | clean |
| `cargo nextest run -p api wallet` | 36/36 passed |
| `cargo nextest run -p dcc-common` | 141/141 passed |
| `cargo build --workspace` | clean, no warnings |
| `cd website && npm run check` | 0 errors, 0 warnings |
| `cd website && npx playwright test wallet-ui --workers 1` | 8/8 passed |

Played the warm stack (web `:59010`, api `:59011`, postgres `:5432`) — no new servers spawned.

## Deviations

- The branch existed from a prior incomplete session (stale worktree at `agent/state/tmp/opencode/dc-wallet-fix`); removed the worktree + branch and re-did the work clean.
- Issue 2 asked to "remove the stale allow". Removing the `#[allow(dead_code)]` naively re-introduces the warning, since `debit_wallet_balance` is genuinely test-only (the dedupe means prod goes through the helper, not through `debit_wallet_balance`). Used `#[cfg(test)]` instead — the honest representation, warning-free in both prod and test builds. Flagging this explicitly since it's a small interpretation call on the issue text.
- Package name for the common crate is `dcc-common`, not `common` (the issue's `-p common` didn't resolve); used `-p dcc-common` throughout.
