### PR TITLE
fix: architecture-aware Hetzner offerings (x86/ARM validation + marketplace display)

### DIFF
--- a/api/src/cloud/hetzner.rs
+++ b/api/src/cloud/hetzner.rs
@@ -167,6 +167,11 @@ struct HetznerServerType {
     cores: i32,
     memory: f64,
     disk: i32,
+    /// CPU architecture reported by Hetzner: "x86" or "arm". Hetzner always
+    /// returns this for server types, and an image MUST match the server
+    /// type's architecture (every system image ships in BOTH variants under
+    /// the SAME name — e.g. "ubuntu-24.04" exists as both x86 and arm).
+    architecture: String,
     prices: Vec<HetznerPrice>,
 }
 
@@ -197,6 +202,10 @@ struct HetznerImage {
     name: Option<String>,
     os_flavor: String,
     status: String,
+    /// Architecture this image variant targets: "x86" or "arm". Hetzner
+    /// returns one image record per (name, architecture), so the same name
+    /// (e.g. "ubuntu-24.04") appears twice — once per arch.
+    architecture: String,
     #[serde(rename = "type")]
     type_: Option<String>,
     description: Option<String>,
@@ -208,6 +217,25 @@ pub struct HetznerProvisionerConfig {
     pub server_type: String,
     pub location: String,
     pub image: String,
+}
+
+/// Catalog-resolved hardware specs for a validated Hetzner offering.
+///
+/// Returned by [`HetznerBackend::validate_offering_config`] so the caller can
+/// (a) inject `architecture` into the offering's `provisioner_config` (the
+/// marketplace surfaces it as a badge/filter), and (b) auto-populate the
+/// offering's spec fields (vCPU / memory / disk) from the authoritative
+/// catalog rather than trusting operator-entered values.
+///
+/// Units match Hetzner's native API: memory in GB (f64), disk in GB (i32).
+/// The offering's display fields also use GB, so no unit conversion is needed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HetznerCatalogSpecs {
+    /// "x86" or "arm" — the architecture of the matched server_type.
+    pub architecture: String,
+    pub cores: i32,
+    pub memory_gb: f64,
+    pub disk_gb: i32,
 }
 
 /// Resolve Hetzner provisioner config from offering fields, applying fallback logic.
@@ -252,11 +280,15 @@ pub fn resolve_provisioner_config(
 
 /// Check that `server_type` exists in the catalog and is available in `location`.
 /// Pure function for testability — the caller fetches the catalog from the API.
-fn check_server_type_location(
-    server_types: &[HetznerServerType],
+///
+/// Returns the matched server type so the caller can read its architecture and
+/// hardware specs (single source of truth for the match — avoids a second
+/// `.find()` in `validate_offering_config`).
+fn check_server_type_location<'a>(
+    server_types: &'a [HetznerServerType],
     server_type: &str,
     location: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<&'a HetznerServerType> {
     let st = server_types
         .iter()
         .find(|s| s.name == server_type)
@@ -288,44 +320,95 @@ fn check_server_type_location(
         );
     }
 
-    Ok(())
+    Ok(st)
 }
 
-/// Check that `image` exists in the Hetzner image catalog.
+/// Check that an image matching `image_name` AND `server_architecture` exists
+/// in the Hetzner image catalog and is provisionable.
+///
+/// Hetzner ships every system image in BOTH x86 and arm variants under the
+/// SAME name (e.g. "ubuntu-24.04" has two records: one per architecture).
+/// Matching by name alone — the old behavior — silently accepted an arm server
+/// type paired with the x86 image id, which Hetzner rejects at provision time.
+/// This cross-validates architecture so the mismatch is caught at offering
+/// validation, with an actionable error listing the architectures actually
+/// available for the requested image name.
+///
 /// Pure function for testability — the caller fetches the catalog from the API.
-fn check_image_exists(images: &[HetznerImage], image_name: &str) -> anyhow::Result<()> {
-    let found = images.iter().any(|img| {
-        img.name.as_deref() == Some(image_name)
-            && img.status == "available"
-            && img.type_.as_deref() != Some("backup")
-    });
+fn check_image_compatible(
+    images: &[HetznerImage],
+    image_name: &str,
+    server_architecture: &str,
+) -> anyhow::Result<()> {
+    // Candidate variants of this image name that are available and not backups.
+    let variants: Vec<&HetznerImage> = images
+        .iter()
+        .filter(|img| {
+            img.name.as_deref() == Some(image_name)
+                && img.status == "available"
+                && img.type_.as_deref() != Some("backup")
+        })
+        .collect();
 
-    if !found {
+    if variants
+        .iter()
+        .any(|img| img.architecture == server_architecture)
+    {
+        return Ok(());
+    }
+
+    // Distinguish "name doesn't exist at all" from "name exists, wrong arch".
+    if variants.is_empty() {
         let known: Vec<&str> = images
             .iter()
             .filter(|img| img.status == "available" && img.type_.as_deref() != Some("backup"))
             .filter_map(|img| img.name.as_deref())
+            // De-dup: every name appears once per architecture; listing
+            // "ubuntu-24.04, ubuntu-24.04" would be noise.
+            .collect::<Vec<&str>>()
+            .into_iter()
             .collect();
+        let mut seen = std::collections::HashSet::new();
+        let unique: Vec<&str> = known.into_iter().filter(|n| seen.insert(*n)).collect();
         anyhow::bail!(
             "Unknown Hetzner image '{}'. Available images: {}",
             image_name,
-            if known.is_empty() {
+            if unique.is_empty() {
                 "(none)".to_string()
             } else {
-                known.join(", ")
+                unique.join(", ")
             }
         );
     }
 
-    Ok(())
+    // Name exists but no variant for the requested architecture.
+    let archs: Vec<&str> = variants.iter().map(|img| img.architecture.as_str()).collect();
+    anyhow::bail!(
+        "Hetzner image '{}' has no variant for architecture '{}'. \
+         Available architectures for '{}': {}",
+        image_name,
+        server_architecture,
+        image_name,
+        if archs.is_empty() {
+            "(none)".to_string()
+        } else {
+            archs.join(", ")
+        }
+    );
 }
 
 impl HetznerBackend {
     /// Validate server_type, location, and image against the live Hetzner catalog.
+    ///
+    /// Cross-validates that the chosen image has a variant matching the server
+    /// type's architecture (every system image ships in BOTH x86 and arm under
+    /// the same name — see [`check_image_compatible`]). Returns the catalog-
+    /// resolved hardware specs so the caller can store architecture + real
+    /// vCPU/memory/disk on the offering.
     pub async fn validate_offering_config(
         &self,
         config: &HetznerProvisionerConfig,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<HetznerCatalogSpecs> {
         // Fetch server types (filtered by name for efficiency)
         let st_response = self
             .request_builder(reqwest::Method::GET, "/server_types")
@@ -339,9 +422,14 @@ impl HetznerBackend {
         }
 
         let st_data: ServerTypesResponse = st_response.json().await?;
-        check_server_type_location(&st_data.server_types, &config.server_type, &config.location)?;
+        let matched = check_server_type_location(
+            &st_data.server_types,
+            &config.server_type,
+            &config.location,
+        )?;
 
-        // Fetch images and validate
+        // Fetch images and validate (architecture cross-checked against the
+        // matched server type — not just the image name).
         let img_response = self
             .request_builder(reqwest::Method::GET, "/images?type=system")
             .send()
@@ -353,9 +441,14 @@ impl HetznerBackend {
         }
 
         let img_data: ImagesResponse = img_response.json().await?;
-        check_image_exists(&img_data.images, &config.image)?;
+        check_image_compatible(&img_data.images, &config.image, &matched.architecture)?;
 
-        Ok(())
+        Ok(HetznerCatalogSpecs {
+            architecture: matched.architecture.clone(),
+            cores: matched.cores,
+            memory_gb: matched.memory,
+            disk_gb: matched.disk,
+        })
     }
 
     fn convert_server(&self, s: HetznerServer) -> Server {
@@ -1004,6 +1097,7 @@ mod tests {
             cores: 2,
             memory: 4.0,
             disk: 40,
+            architecture: "x86".to_string(),
             prices: vec![HetznerPrice {
                 location: "fsn1".to_string(),
                 price_monthly: HetznerPriceDetail {
@@ -1028,6 +1122,7 @@ mod tests {
             cores: 2,
             memory: 4.0,
             disk: 40,
+            architecture: "x86".to_string(),
             prices: vec![],
         };
         let converted = backend.convert_server_type(st);
@@ -1048,6 +1143,7 @@ mod tests {
             cores: 2,
             memory: 4.0,
             disk: 40,
+            architecture: "x86".to_string(),
             prices: vec![HetznerPrice {
                 location: "fsn1".to_string(),
                 price_monthly: HetznerPriceDetail {
@@ -1072,6 +1168,7 @@ mod tests {
             "name": "ubuntu-22.04",
             "os_flavor": "ubuntu",
             "status": "available",
+            "architecture": "x86",
             "type": "system",
             "description": "Ubuntu 22.04 LTS"
         }"#;
@@ -1079,6 +1176,7 @@ mod tests {
         assert_eq!(img.id, 67794396);
         assert_eq!(img.type_, Some("system".to_string()));
         assert_eq!(img.os_flavor, "ubuntu");
+        assert_eq!(img.architecture, "x86");
     }
 
     #[test]
@@ -1089,6 +1187,7 @@ mod tests {
             name: Some("old-image".to_string()),
             os_flavor: "ubuntu".to_string(),
             status: "deprecated".to_string(),
+            architecture: "x86".to_string(),
             type_: Some("system".to_string()),
             description: None,
         };
@@ -1103,6 +1202,7 @@ mod tests {
             name: Some("my-backup".to_string()),
             os_flavor: "ubuntu".to_string(),
             status: "available".to_string(),
+            architecture: "x86".to_string(),
             type_: Some("backup".to_string()),
             description: None,
         };
@@ -1118,6 +1218,7 @@ mod tests {
                 "cores": 2,
                 "memory": 2.0,
                 "disk": 40,
+                "architecture": "x86",
                 "prices": [{
                     "location": "fsn1",
                     "price_monthly": {"net": "4.0756", "gross": "4.8499"},
@@ -1128,6 +1229,7 @@ mod tests {
         let resp: ServerTypesResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.server_types.len(), 1);
         assert_eq!(resp.server_types[0].name, "cpx11");
+        assert_eq!(resp.server_types[0].architecture, "x86");
     }
 
     fn make_test_catalog() -> Vec<HetznerServerType> {
@@ -1138,6 +1240,7 @@ mod tests {
                 cores: 2,
                 memory: 4.0,
                 disk: 40,
+                architecture: "x86".to_string(),
                 prices: vec![
                     HetznerPrice {
                         location: "fsn1".to_string(),
@@ -1165,6 +1268,7 @@ mod tests {
                 cores: 2,
                 memory: 8.0,
                 disk: 80,
+                architecture: "x86".to_string(),
                 prices: vec![HetznerPrice {
                     location: "fsn1".to_string(),
                     price_monthly: HetznerPriceDetail {
@@ -1268,12 +1372,25 @@ mod tests {
     }
 
     fn make_test_images() -> Vec<HetznerImage> {
+        // Mirrors the real Hetzner catalog shape: "ubuntu-24.04" ships in BOTH
+        // x86 and arm variants under the same name. Other images are single-arch
+        // to exercise the mismatch path.
         vec![
             HetznerImage {
                 id: 1,
                 name: Some("ubuntu-24.04".to_string()),
                 os_flavor: "ubuntu".to_string(),
                 status: "available".to_string(),
+                architecture: "x86".to_string(),
+                type_: Some("system".to_string()),
+                description: Some("Ubuntu 24.04".to_string()),
+            },
+            HetznerImage {
+                id: 5,
+                name: Some("ubuntu-24.04".to_string()),
+                os_flavor: "ubuntu".to_string(),
+                status: "available".to_string(),
+                architecture: "arm".to_string(),
                 type_: Some("system".to_string()),
                 description: Some("Ubuntu 24.04".to_string()),
             },
@@ -1282,6 +1399,7 @@ mod tests {
                 name: Some("debian-12".to_string()),
                 os_flavor: "debian".to_string(),
                 status: "available".to_string(),
+                architecture: "x86".to_string(),
                 type_: Some("system".to_string()),
                 description: Some("Debian 12".to_string()),
             },
@@ -1290,6 +1408,7 @@ mod tests {
                 name: Some("old-image".to_string()),
                 os_flavor: "ubuntu".to_string(),
                 status: "deprecated".to_string(),
+                architecture: "x86".to_string(),
                 type_: Some("system".to_string()),
                 description: None,
             },
@@ -1298,6 +1417,7 @@ mod tests {
                 name: Some("my-backup".to_string()),
                 os_flavor: "ubuntu".to_string(),
                 status: "available".to_string(),
+                architecture: "x86".to_string(),
                 type_: Some("backup".to_string()),
                 description: None,
             },
@@ -1305,16 +1425,61 @@ mod tests {
     }
 
     #[test]
-    fn test_check_image_exists_valid() {
+    fn test_check_image_compatible_accepts_matching_architecture() {
         let images = make_test_images();
-        assert!(check_image_exists(&images, "ubuntu-24.04").is_ok());
-        assert!(check_image_exists(&images, "debian-12").is_ok());
+        // cx23 is x86 — the x86 variant of ubuntu-24.04 must match.
+        assert!(check_image_compatible(&images, "ubuntu-24.04", "x86").is_ok());
+        // cax11 is arm — the arm variant must be found, NOT the x86 one.
+        assert!(check_image_compatible(&images, "ubuntu-24.04", "arm").is_ok());
+        // Single-arch image: debian-12 x86 matches x86 server.
+        assert!(check_image_compatible(&images, "debian-12", "x86").is_ok());
     }
 
     #[test]
-    fn test_check_image_exists_invalid() {
+    fn test_check_image_compatible_rejects_wrong_architecture() {
+        // debian-12 ships ONLY as x86 in this catalog; an arm server type must
+        // be rejected rather than silently paired with the x86 image id (which
+        // Hetzner refuses at provision time).
         let images = make_test_images();
-        let err = check_image_exists(&images, "nonexistent")
+        let err = check_image_compatible(&images, "debian-12", "arm")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("no variant for architecture 'arm'"),
+            "error should explain the architecture mismatch: {err}"
+        );
+        assert!(
+            err.contains("debian-12"),
+            "error should name the image: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_image_compatible_lists_available_archs_on_mismatch() {
+        // On a name-exists-but-arch-mismatch, the error MUST enumerate the
+        // architectures actually available for that image name so the operator
+        // can pick a compatible server type.
+        let images = make_test_images();
+        let err = check_image_compatible(&images, "debian-12", "arm")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Available architectures"),
+            "error should list available architectures: {err}"
+        );
+        assert!(
+            err.contains("x86"),
+            "error should list the x86 variant: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_image_compatible_unknown_image_name() {
+        // A name that matches no variant at all is "unknown image", not an
+        // architecture mismatch — and the list de-dups names that appear once
+        // per architecture (no "ubuntu-24.04, ubuntu-24.04").
+        let images = make_test_images();
+        let err = check_image_compatible(&images, "nonexistent", "x86")
             .unwrap_err()
             .to_string();
         assert!(
@@ -1325,7 +1490,13 @@ mod tests {
             err.contains("ubuntu-24.04") && err.contains("debian-12"),
             "error should list available images: {err}"
         );
-        // Deprecated and backup images should NOT appear in the list
+        // The dual-arch ubuntu-24.04 must appear only once.
+        assert_eq!(
+            err.matches("ubuntu-24.04").count(),
+            1,
+            "dual-arch image name should be de-duplicated: {err}"
+        );
+        // Deprecated and backup images should NOT appear in the list.
         assert!(
             !err.contains("old-image"),
             "deprecated images should not be listed: {err}"
@@ -1337,9 +1508,9 @@ mod tests {
     }
 
     #[test]
-    fn test_check_image_exists_deprecated_rejected() {
+    fn test_check_image_compatible_deprecated_rejected() {
         let images = make_test_images();
-        let err = check_image_exists(&images, "old-image")
+        let err = check_image_compatible(&images, "old-image", "x86")
             .unwrap_err()
             .to_string();
         assert!(

--- a/api/src/openapi/providers.rs
+++ b/api/src/openapi/providers.rs
@@ -337,15 +337,22 @@ pub fn normalize_provisioning_details(
 /// `pub(crate)` so the extracted `OfferingCsvApi` (CSV import post-validation)
 /// can call it; it stays here because the offering create/update handlers in
 /// `ProvidersApi` are the other caller.
+///
+/// Returns `Some(HetznerCatalogSpecs)` for validated Hetzner offerings so the
+/// caller can record architecture + catalog-resolved hardware on the offering.
+/// `None` for vultr / non-cloud offerings (no catalog specs to inject today).
 pub(crate) async fn validate_cloud_offering(
     db: &Database,
     offering: &crate::database::offerings::Offering,
     pubkey_bytes: &[u8],
-) -> Result<(), String> {
+) -> Result<Option<crate::cloud::hetzner::HetznerCatalogSpecs>, String> {
     match offering.provisioner_type.as_deref() {
         Some("hetzner") => validate_hetzner_offering_inner(db, offering, pubkey_bytes).await,
-        Some("vultr") => validate_vultr_offering_inner(db, offering, pubkey_bytes).await,
-        _ => Ok(()),
+        Some("vultr") => {
+            validate_vultr_offering_inner(db, offering, pubkey_bytes).await?;
+            Ok(None)
+        }
+        _ => Ok(None),
     }
 }
 
@@ -353,7 +360,7 @@ async fn validate_hetzner_offering_inner(
     db: &Database,
     offering: &crate::database::offerings::Offering,
     pubkey_bytes: &[u8],
-) -> Result<(), String> {
+) -> Result<Option<crate::cloud::hetzner::HetznerCatalogSpecs>, String> {
     let config = crate::cloud::hetzner::resolve_provisioner_config(
         offering.provisioner_config.as_deref(),
         &offering.datacenter_city,
@@ -386,12 +393,12 @@ async fn validate_hetzner_offering_inner(
     let backend = crate::cloud::hetzner::HetznerBackend::new(token)
         .map_err(|e| format!("Failed to create Hetzner client: {e:#}"))?;
 
-    backend
+    let specs = backend
         .validate_offering_config(&config)
         .await
         .map_err(|e| format!("Hetzner offering validation failed: {e:#}"))?;
 
-    Ok(())
+    Ok(Some(specs))
 }
 
 async fn validate_vultr_offering_inner(
@@ -437,6 +444,73 @@ async fn validate_vultr_offering_inner(
         .map_err(|e| format!("Vultr offering validation failed: {e:#}"))?;
 
     Ok(())
+}
+
+/// Record Hetzner catalog-resolved specs onto an offering before it is stored.
+///
+/// Cloud-resell offerings are typically created with only `server_type` /
+/// `location` / `image` in `provisioner_config`, leaving the marketplace spec
+/// fields blank. This (a) injects `architecture` into the `provisioner_config`
+/// JSON so the marketplace can surface and filter by it, and (b) auto-populates
+/// vCPU / memory / disk from the authoritative catalog when the operator left
+/// them blank. Operator-provided values are NEVER overwritten — only filled.
+///
+/// `architecture` becomes the single source of truth derived from the catalog
+/// (never operator-typed), so it can't drift from the actual server_type.
+fn apply_hetzner_catalog_specs(
+    offering: &mut crate::database::offerings::Offering,
+    specs: &crate::cloud::hetzner::HetznerCatalogSpecs,
+) {
+    // (a) Merge architecture into provisioner_config JSON. This was already
+    // parsed successfully inside validate_hetzner_offering_inner's
+    // resolve_provisioner_config, so a re-parse failure here is impossible in
+    // practice — log loudly if it ever happens rather than silently dropping.
+    let mut config: serde_json::Value = match offering.provisioner_config.as_deref() {
+        Some(raw) => serde_json::from_str(raw).unwrap_or_else(|e| {
+            tracing::warn!(
+                raw_provisioner_config = raw,
+                error = %e,
+                "provisioner_config failed to re-parse after validation; \
+                 architecture will be written into a fresh config object"
+            );
+            serde_json::json!({})
+        }),
+        None => serde_json::json!({}),
+    };
+    if let Some(obj) = config.as_object_mut() {
+        obj.insert(
+            "architecture".to_string(),
+            serde_json::Value::String(specs.architecture.clone()),
+        );
+    } else {
+        // provisioner_config parsed to a non-object (e.g. a bare string/array);
+        // replace it with an object carrying architecture + the original value.
+        tracing::warn!(
+            raw_provisioner_config = ?offering.provisioner_config,
+            "provisioner_config was not a JSON object; replacing with architecture object"
+        );
+        config = serde_json::json!({ "architecture": specs.architecture });
+    }
+    match serde_json::to_string(&config) {
+        Ok(serialized) => offering.provisioner_config = Some(serialized),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "failed to re-serialize provisioner_config with architecture; leaving unchanged"
+        ),
+    }
+
+    // (b) Auto-populate spec fields only when the operator left them blank.
+    // Units match existing display + filter conventions: memory and disk as GB
+    // strings (the marketplace memory/SSD filters parse GB from these fields).
+    if offering.processor_cores.is_none() {
+        offering.processor_cores = Some(specs.cores as i64);
+    }
+    if offering.memory_amount.is_none() {
+        offering.memory_amount = Some(format!("{} GB", specs.memory_gb));
+    }
+    if offering.total_ssd_capacity.is_none() {
+        offering.total_ssd_capacity = Some(format!("{} GB", specs.disk_gb));
+    }
 }
 
 pub struct ProvidersApi;
@@ -1367,12 +1441,16 @@ impl ProvidersApi {
             });
         }
 
-        if let Err(e) = validate_cloud_offering(&db, &params, &pubkey_bytes).await {
-            return Json(ApiResponse {
-                success: false,
-                data: None,
-                error: Some(e),
-            });
+        match validate_cloud_offering(&db, &params, &pubkey_bytes).await {
+            Ok(Some(specs)) => apply_hetzner_catalog_specs(&mut params, &specs),
+            Ok(None) => {}
+            Err(e) => {
+                return Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    error: Some(e),
+                });
+            }
         }
 
         if let Err(e) = validate_recipe_if_present(params.post_provision_script.as_ref()) {
@@ -1449,12 +1527,16 @@ impl ProvidersApi {
             });
         }
 
-        if let Err(e) = validate_cloud_offering(&db, &params, &pubkey_bytes).await {
-            return Json(ApiResponse {
-                success: false,
-                data: None,
-                error: Some(e),
-            });
+        match validate_cloud_offering(&db, &params, &pubkey_bytes).await {
+            Ok(Some(specs)) => apply_hetzner_catalog_specs(&mut params, &specs),
+            Ok(None) => {}
+            Err(e) => {
+                return Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    error: Some(e),
+                });
+            }
         }
 
         if let Err(e) = validate_recipe_if_present(params.post_provision_script.as_ref()) {
@@ -4078,5 +4160,170 @@ mod tests {
         for key in ["trustMetrics", "responseMetrics", "healthSummary", "offerings", "activity"] {
             assert!(obj.contains_key(key), "missing camelCase key `{key}`");
         }
+    }
+
+    // ── apply_hetzner_catalog_specs ─────────────────────────────────────────
+
+    /// Build an Offering with only the fields relevant to spec injection
+    /// populated; everything else defaults. Avoids dragging the full Offering
+    /// constructor into every assertion below.
+    fn blank_offering() -> crate::database::offerings::Offering {
+        use crate::database::offerings::Offering;
+        Offering {
+            id: None,
+            pubkey: String::new(),
+            offering_id: "test".to_string(),
+            offer_name: "Test".to_string(),
+            description: None,
+            product_page_url: None,
+            currency: "USD".to_string(),
+            monthly_price: 10.0,
+            setup_fee: 0.0,
+            visibility: "public".to_string(),
+            product_type: "compute".to_string(),
+            virtualization_type: None,
+            billing_interval: "monthly".to_string(),
+            billing_unit: "month".to_string(),
+            pricing_model: None,
+            price_per_unit: None,
+            included_units: None,
+            overage_price_per_unit: None,
+            stripe_metered_price_id: None,
+            is_subscription: false,
+            subscription_interval_days: None,
+            stock_status: "in_stock".to_string(),
+            processor_brand: None,
+            processor_amount: None,
+            processor_cores: None,
+            processor_speed: None,
+            processor_name: None,
+            memory_error_correction: None,
+            memory_type: None,
+            memory_amount: None,
+            hdd_amount: None,
+            total_hdd_capacity: None,
+            ssd_amount: None,
+            total_ssd_capacity: None,
+            unmetered_bandwidth: false,
+            uplink_speed: None,
+            traffic: None,
+            datacenter_country: "DE".to_string(),
+            datacenter_city: "Falkenstein".to_string(),
+            datacenter_latitude: None,
+            datacenter_longitude: None,
+            control_panel: None,
+            gpu_name: None,
+            gpu_count: None,
+            gpu_memory_gb: None,
+            min_contract_hours: None,
+            max_contract_hours: None,
+            payment_methods: None,
+            features: None,
+            operating_systems: None,
+            trust_score: None,
+            has_critical_flags: None,
+            reliability_score: None,
+            is_draft: false,
+            offering_source: None,
+            external_checkout_url: None,
+            reseller_name: None,
+            reseller_commission_percent: None,
+            owner_username: None,
+            provider_name: None,
+            provisioner_type: Some("hetzner".to_string()),
+            provisioner_config: None,
+            template_name: None,
+            agent_pool_id: None,
+            post_provision_script: None,
+            provider_online: None,
+            resolved_pool_id: None,
+            resolved_pool_name: None,
+            created_at_ns: None,
+            publish_at: None,
+        }
+    }
+
+    #[test]
+    fn test_apply_hetzner_catalog_specs_injects_architecture_and_specs() {
+        let mut offering = blank_offering();
+        // Cloud-resell offering created with NO provisioner_config and no spec
+        // fields — the common case the helper exists to fill in.
+        let specs = crate::cloud::hetzner::HetznerCatalogSpecs {
+            architecture: "arm".to_string(),
+            cores: 2,
+            memory_gb: 4.0,
+            disk_gb: 40,
+        };
+        super::apply_hetzner_catalog_specs(&mut offering, &specs);
+
+        // Architecture recorded in provisioner_config JSON.
+        let config: serde_json::Value =
+            serde_json::from_str(offering.provisioner_config.as_deref().unwrap_or("{}"))
+                .expect("provisioner_config must be valid JSON");
+        assert_eq!(config["architecture"], "arm");
+
+        // Spec fields auto-populated from the catalog (GB units match the
+        // marketplace display + filter convention).
+        assert_eq!(offering.processor_cores, Some(2));
+        assert_eq!(offering.memory_amount.as_deref(), Some("4 GB"));
+        assert_eq!(offering.total_ssd_capacity.as_deref(), Some("40 GB"));
+    }
+
+    #[test]
+    fn test_apply_hetzner_catalog_specs_preserves_existing_config_keys() {
+        let mut offering = blank_offering();
+        offering.provisioner_config =
+            Some(r#"{"server_type":"cax11","location":"fsn1","image":"ubuntu-24.04"}"#.to_string());
+        let specs = crate::cloud::hetzner::HetznerCatalogSpecs {
+            architecture: "arm".to_string(),
+            cores: 2,
+            memory_gb: 4.0,
+            disk_gb: 40,
+        };
+        super::apply_hetzner_catalog_specs(&mut offering, &specs);
+
+        let config: serde_json::Value =
+            serde_json::from_str(offering.provisioner_config.as_deref().unwrap())
+                .expect("provisioner_config must stay valid JSON");
+        // Architecture added.
+        assert_eq!(config["architecture"], "arm");
+        // Operator-provided keys preserved.
+        assert_eq!(config["server_type"], "cax11");
+        assert_eq!(config["location"], "fsn1");
+        assert_eq!(config["image"], "ubuntu-24.04");
+    }
+
+    #[test]
+    fn test_apply_hetzner_catalog_specs_does_not_overwrite_operator_specs() {
+        // An operator who set their own spec values keeps them — the catalog
+        // only fills BLANK fields, never overrides (DRY: catalog is fallback,
+        // not authority, for human-curated fields).
+        let mut offering = blank_offering();
+        offering.processor_cores = Some(8);
+        offering.memory_amount = Some("32 GB ECC".to_string());
+        offering.total_ssd_capacity = Some("1 TB".to_string());
+        let specs = crate::cloud::hetzner::HetznerCatalogSpecs {
+            architecture: "x86".to_string(),
+            cores: 2,
+            memory_gb: 4.0,
+            disk_gb: 40,
+        };
+        super::apply_hetzner_catalog_specs(&mut offering, &specs);
+
+        assert_eq!(offering.processor_cores, Some(8), "operator cores preserved");
+        assert_eq!(
+            offering.memory_amount.as_deref(),
+            Some("32 GB ECC"),
+            "operator memory preserved"
+        );
+        assert_eq!(
+            offering.total_ssd_capacity.as_deref(),
+            Some("1 TB"),
+            "operator disk preserved"
+        );
+        // Architecture is still injected (it's always catalog-derived).
+        let config: serde_json::Value =
+            serde_json::from_str(offering.provisioner_config.as_deref().unwrap_or("{}")).unwrap();
+        assert_eq!(config["architecture"], "x86");
     }
 }

--- a/website/src/lib/utils/marketplace-filters.test.ts
+++ b/website/src/lib/utils/marketplace-filters.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { filterInStock, isOfferingPaused, filterOfflineOfferings, isOfferingRentable } from './marketplace-filters';
+import {
+	filterInStock,
+	isOfferingPaused,
+	filterOfflineOfferings,
+	isOfferingRentable,
+	parseArchitecture,
+	formatArchitectureLabel,
+	ARCHITECTURES,
+} from './marketplace-filters';
 
 // ---------- isOfferingPaused ----------
 describe('isOfferingPaused', () => {
@@ -269,5 +277,75 @@ describe('isOfferingRentable', () => {
 
 	it('treats undefined has_critical_flags as rentable (no flags)', () => {
 		expect(isOfferingRentable({ provider_online: true, has_critical_flags: undefined })).toBe(true);
+	});
+});
+
+// ---------- architecture helpers (parseArchitecture / formatArchitectureLabel) ----------
+describe('parseArchitecture', () => {
+	it('parses x86 from provisioner_config JSON', () => {
+		expect(parseArchitecture('{"server_type":"cx23","architecture":"x86"}')).toBe('x86');
+	});
+
+	it('parses arm from provisioner_config JSON', () => {
+		expect(parseArchitecture('{"server_type":"cax11","architecture":"arm"}')).toBe('arm');
+	});
+
+	it('returns undefined when architecture key is absent (non-cloud offering)', () => {
+		expect(parseArchitecture('{"server_type":"cx23","location":"fsn1"}')).toBeUndefined();
+	});
+
+	it('returns undefined for undefined / null / empty input', () => {
+		expect(parseArchitecture(undefined)).toBeUndefined();
+		expect(parseArchitecture(null)).toBeUndefined();
+		expect(parseArchitecture('')).toBeUndefined();
+	});
+
+	it('returns undefined for malformed JSON instead of throwing', () => {
+		expect(parseArchitecture('not-json')).toBeUndefined();
+		expect(parseArchitecture('{broken')).toBeUndefined();
+	});
+
+	it('returns undefined when architecture is present but not a string', () => {
+		expect(parseArchitecture('{"architecture":42}')).toBeUndefined();
+		expect(parseArchitecture('{"architecture":null}')).toBeUndefined();
+	});
+
+	it('returns undefined when provisioner_config is a JSON non-object', () => {
+		// A bare string/array is not a valid provisioner_config; treat as no arch.
+		expect(parseArchitecture('"hello"')).toBeUndefined();
+		expect(parseArchitecture('["x86"]')).toBeUndefined();
+	});
+});
+
+describe('formatArchitectureLabel', () => {
+	it('renders arm as ARM64', () => {
+		expect(formatArchitectureLabel('arm')).toBe('ARM64');
+	});
+
+	it('renders x86 as x86 (conventional casing preserved)', () => {
+		expect(formatArchitectureLabel('x86')).toBe('x86');
+	});
+
+	it('is case-insensitive on input (API always lowercases, but be resilient)', () => {
+		expect(formatArchitectureLabel('ARM')).toBe('ARM64');
+		expect(formatArchitectureLabel('X86')).toBe('x86');
+	});
+
+	it('passes unknown architectures through unchanged', () => {
+		expect(formatArchitectureLabel('riscv')).toBe('riscv');
+	});
+
+	it('returns undefined for empty / undefined input', () => {
+		expect(formatArchitectureLabel(undefined)).toBeUndefined();
+		expect(formatArchitectureLabel(null)).toBeUndefined();
+		expect(formatArchitectureLabel('')).toBeUndefined();
+	});
+
+	it('round-trips: every accepted ARCHITECTURES value has a non-empty label', () => {
+		for (const arch of ARCHITECTURES) {
+			const label = formatArchitectureLabel(arch);
+			expect(typeof label).toBe('string');
+			expect(label!.length).toBeGreaterThan(0);
+		}
 	});
 });

--- a/website/src/lib/utils/marketplace-filters.ts
+++ b/website/src/lib/utils/marketplace-filters.ts
@@ -74,3 +74,49 @@ export function filterOfflineOfferings<T extends OfferingOnline>(
 export function isOfferingRentable<T extends OfferingRentable>(offering: T): boolean {
 	return offering.provider_online !== false && offering.has_critical_flags !== true;
 }
+
+/**
+ * The raw CPU architecture values Hetzner reports and that the API injects into
+ * an offering's `provisioner_config`. Kept here as the single source of truth so
+ * the filter pills and the parser agree on the accepted set.
+ */
+export const ARCHITECTURES = ['x86', 'arm'] as const;
+export type Architecture = (typeof ARCHITECTURES)[number];
+
+/**
+ * Parse the CPU architecture from an offering's `provisioner_config` JSON string.
+ *
+ * Hetzner cloud-resell offerings store architecture ("x86" or "arm") in
+ * `provisioner_config` (injected by the API from the Hetzner catalog, so it
+ * always matches the actual server_type). Returns the raw value, or `undefined`
+ * for non-cloud offerings and older offerings created before architecture
+ * injection landed. Invalid JSON is treated as "no architecture" rather than
+ * throwing — the marketplace must never crash on a malformed config string.
+ */
+export function parseArchitecture(provisionerConfig: string | undefined | null): string | undefined {
+	if (!provisionerConfig) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(provisionerConfig);
+		if (parsed && typeof parsed === 'object') {
+			const arch = (parsed as Record<string, unknown>)?.architecture;
+			return typeof arch === 'string' ? arch : undefined;
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Human-readable architecture label for badges/display: "arm" -> "ARM64",
+ * "x86" -> "x86" (already the conventional casing). Unknown values pass through
+ * as-is. Returns `undefined` when there is no architecture to show so callers
+ * can `{#if}` the badge away cleanly.
+ */
+export function formatArchitectureLabel(architecture: string | undefined | null): string | undefined {
+	if (!architecture) return undefined;
+	const normalized = architecture.toLowerCase();
+	if (normalized === 'arm') return 'ARM64';
+	if (normalized === 'x86') return 'x86';
+	return architecture;
+}

--- a/website/src/routes/dashboard/marketplace/+page.svelte
+++ b/website/src/routes/dashboard/marketplace/+page.svelte
@@ -17,6 +17,7 @@
 	import { getRecentlyViewed } from "$lib/utils/recently-viewed";
 	import { buildQuickPillClass, buildRowActionButtonClass } from "$lib/utils/marketplace-ui";
 	import { buildDashboardCtaClass } from "$lib/utils/dashboard-cta";
+	import { parseArchitecture, formatArchitectureLabel, type Architecture } from "$lib/utils/marketplace-filters";
 	import Button from "$lib/components/Button.svelte";
 
 	let offerings = $state<Offering[]>([]);
@@ -60,6 +61,9 @@
 	let recipesOnly = $state(false);
 	let inStockOnly = $state(true);
 	let providerFilter = $state<string>('');
+	// Architecture filter (Hetzner cloud-resell): '' = All, 'x86', or 'arm'.
+	// Compared against the raw value parsed from each offering's provisioner_config.
+	let selectedArch = $state<Architecture | ''>("");
 	let recentlyViewedIds = $state<number[]>([]);
 	let trendingOfferings = $state<TrendingOffering[]>([]);
 	let recommendedOfferings = $state<RecommendedOffering[]>([]);
@@ -213,6 +217,15 @@
 			);
 		}
 
+		// Client-side architecture filter (Hetzner cloud-resell). Matches the
+		// raw arch value injected into provisioner_config; offerings without an
+		// architecture never match a specific arch filter.
+		if (selectedArch) {
+			result = result.filter(
+				(o) => parseArchitecture(o.provisioner_config) === selectedArch,
+			);
+		}
+
 		// Client-side unmetered filter
 		if (unmeteredOnly) {
 			result = result.filter((o) => o.unmetered_bandwidth);
@@ -316,6 +329,21 @@
 			selectedPreset !== null
 	);
 
+	// Architecture pill availability: how many current offerings carry each arch
+	// (parsed from provisioner_config). Pills hide when zero match and none is
+	// selected, mirroring presetAvailability. Drives the x86 / ARM64 quick filter.
+	let archAvailability = $derived.by(() => {
+		const base = showOfflineOfferings ? offerings : offerings.filter((o) => o.provider_online);
+		let x86 = 0;
+		let arm = 0;
+		for (const o of base) {
+			const arch = parseArchitecture(o.provisioner_config);
+			if (arch === 'x86') x86++;
+			else if (arch === 'arm') arm++;
+		}
+		return { x86, arm };
+	});
+
 	authStore.isAuthenticated.subscribe((value) => {
 		isAuthenticated = value;
 	});
@@ -408,6 +436,7 @@
 		minMemoryGb = p.has('minMemoryGb') ? Number(p.get('minMemoryGb')) : null;
 		minSsdGb = p.has('minSsdGb') ? Number(p.get('minSsdGb')) : null;
 		selectedVirt = p.get('virt') ?? '';
+		selectedArch = (p.get('arch') as Architecture | '') ?? '';
 		unmeteredOnly = p.get('unmetered') === '1';
 		minTrust = p.has('minTrust') ? Number(p.get('minTrust')) : null;
 		showOfflineOfferings = p.get('offline') === '1';
@@ -433,6 +462,7 @@
 		if (minMemoryGb != null) params.set('minMemoryGb', String(minMemoryGb));
 		if (minSsdGb != null) params.set('minSsdGb', String(minSsdGb));
 		if (selectedVirt) params.set('virt', selectedVirt);
+		if (selectedArch) params.set('arch', selectedArch);
 		if (unmeteredOnly) params.set('unmetered', '1');
 		if (minTrust != null) params.set('minTrust', String(minTrust));
 		if (showOfflineOfferings) params.set('offline', '1');
@@ -534,6 +564,7 @@
 		minMemoryGb = null;
 		minSsdGb = null;
 		selectedVirt = "";
+		selectedArch = "";
 		unmeteredOnly = false;
 		minTrust = null;
 		showOfflineOfferings = false;
@@ -686,6 +717,13 @@
 		return parts.join(" · ") || "—";
 	}
 
+	// Architecture badge label for an offering, parsed from its provisioner_config
+	// (injected by the API for Hetzner cloud-resell offerings). Undefined when the
+	// offering has no architecture to show.
+	function archBadge(offering: Offering): string | undefined {
+		return formatArchitectureLabel(parseArchitecture(offering.provisioner_config));
+	}
+
 	function formatLocation(offering: Offering): string {
 		if (offering.datacenter_city && offering.datacenter_country) {
 			return `${offering.datacenter_city}, ${offering.datacenter_country}`;
@@ -729,7 +767,8 @@
 	let hasActiveFilters = $derived(
 		selectedTypes.size > 0 || searchQuery !== '' || selectedRegion !== '' || selectedCountry !== '' ||
 		selectedCity !== '' || minPrice !== null || maxPrice !== null || minCores !== null ||
-		minMemoryGb !== null || minSsdGb !== null || selectedVirt !== '' || unmeteredOnly ||
+		minMemoryGb !== null || minSsdGb !== null || selectedVirt !== '' || selectedArch !== '' ||
+		unmeteredOnly ||
 		minTrust !== null || showOfflineOfferings || recipesOnly || !inStockOnly ||
 		quickFilter !== null || selectedPreset !== null
 	);
@@ -772,6 +811,10 @@
 		}
 		if (selectedVirt) {
 			chips.push({ label: `Virt: ${selectedVirt.toUpperCase()}`, remove: () => { selectedVirt = ""; syncFiltersToUrl(); } });
+		}
+		if (selectedArch) {
+			const archLabel = formatArchitectureLabel(selectedArch) ?? selectedArch;
+			chips.push({ label: `Arch: ${archLabel}`, remove: () => { selectedArch = ""; syncFiltersToUrl(); } });
 		}
 		if (unmeteredOnly) {
 			chips.push({ label: "Unmetered", remove: () => { unmeteredOnly = false; syncFiltersToUrl(); } });
@@ -1160,15 +1203,41 @@
 						North America
 					</button>
 				{/if}
-				{#if presetAvailability.europe > 0 || selectedPreset === 'europe'}
+			{#if presetAvailability.europe > 0 || selectedPreset === 'europe'}
+				<button
+					onclick={() => setPreset("europe")}
+					class={buildQuickPillClass('preset', selectedPreset === 'europe', 'sky')}
+				>
+					Europe
+				</button>
+			{/if}
+			{#if archAvailability.x86 > 0 || archAvailability.arm > 0 || selectedArch}
+				<div class="w-px h-5 bg-neutral-700 mx-1"></div>
+				<span class="text-neutral-600 text-xs shrink-0">Arch:</span>
+				<button
+					onclick={() => { selectedArch = ""; syncFiltersToUrl(); }}
+					class={buildQuickPillClass('filter', selectedArch === '', 'neutral')}
+				>
+					All
+				</button>
+				{#if archAvailability.x86 > 0 || selectedArch === 'x86'}
 					<button
-						onclick={() => setPreset("europe")}
-						class={buildQuickPillClass('preset', selectedPreset === 'europe', 'sky')}
+						onclick={() => { selectedArch = "x86"; syncFiltersToUrl(); }}
+						class={buildQuickPillClass('filter', selectedArch === 'x86', 'sky')}
 					>
-						Europe
+						x86
 					</button>
 				{/if}
-			</div>
+				{#if archAvailability.arm > 0 || selectedArch === 'arm'}
+					<button
+						onclick={() => { selectedArch = "arm"; syncFiltersToUrl(); }}
+						class={buildQuickPillClass('filter', selectedArch === 'arm', 'emerald')}
+					>
+						ARM64
+					</button>
+				{/if}
+			{/if}
+		</div>
 			</div>
 
 			<!-- Search Bar with Icon -->
@@ -1454,7 +1523,15 @@
 									>
 								</td>
 									<td class="py-3 pr-4 text-neutral-300"
-										>{formatSpecs(offering)}</td
+										><div class="flex items-center gap-1.5 flex-wrap"
+											><span>{formatSpecs(offering)}</span
+											>{#if archBadge(offering)}
+												<span
+													class="marketplace-arch-badge inline-flex items-center text-[10px] font-semibold tracking-wide px-1.5 py-0.5 rounded bg-surface-elevated text-neutral-300 border border-neutral-700"
+													title="{offering.offer_name} runs on the {archBadge(offering)} architecture"
+												>{archBadge(offering)}</span>
+											{/if}</div
+										></td
 									>
 									<td class="py-3 pr-4 text-neutral-300"
 										>{formatLocation(offering)}</td
@@ -1769,8 +1846,13 @@
 									{/if}
 								</div>
 							</div>
-							<div class="text-sm text-neutral-400 mb-2">
-								{formatSpecs(offering)}
+							<div class="text-sm text-neutral-400 mb-2 flex items-center gap-1.5 flex-wrap">
+								<span>{formatSpecs(offering)}</span>
+								{#if archBadge(offering)}
+									<span
+										class="marketplace-arch-badge inline-flex items-center text-[10px] font-semibold tracking-wide px-1.5 py-0.5 rounded bg-surface-elevated text-neutral-300 border border-neutral-700"
+									>{archBadge(offering)}</span>
+								{/if}
 							</div>
 							<div class="flex items-center justify-between">
 								<div>

--- a/website/src/routes/dashboard/marketplace/[id]/+page.svelte
+++ b/website/src/routes/dashboard/marketplace/[id]/+page.svelte
@@ -31,6 +31,7 @@
 	import { Ed25519KeyIdentity } from '@dfinity/identity';
 	import { providerDisplayName } from '$lib/utils/provider-display';
 	import { recordView } from '$lib/utils/recently-viewed';
+	import { parseArchitecture, formatArchitectureLabel } from '$lib/utils/marketplace-filters';
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import SlaBreachTimeline from '$lib/components/SlaBreachTimeline.svelte';
 	import { filterSimilarOfferings } from './similar-offerings';
@@ -663,6 +664,12 @@
 		<div class="card p-6 border border-neutral-800">
 			<h2 class="text-sm font-medium text-neutral-500 uppercase tracking-wide mb-4">Specifications</h2>
 			<div class="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+				{#if formatArchitectureLabel(parseArchitecture(offering.provisioner_config))}
+					<div>
+						<span class="text-neutral-500 text-xs block">Architecture</span>
+						<span class="text-white">{formatArchitectureLabel(parseArchitecture(offering.provisioner_config))}</span>
+					</div>
+				{/if}
 				{#if offering.processor_cores}
 					<div>
 						<span class="text-neutral-500 text-xs block">vCPUs</span>


### PR DESCRIPTION
## Problem
Every Hetzner system image exists in BOTH x86 and arm variants with the SAME name (e.g. `ubuntu-24.04` has both x86 and arm entries). The code ignored architecture entirely — no cross-validation, no display, no filtering.

## Fix
- **Backend (`hetzner.rs`):** Added `architecture` to `HetznerServerType` + `HetznerImage` structs. `check_image_exists`→`check_image_compatible(images, name, server_arch)` cross-validates that the image exists for the server_type's architecture. Returns `HetznerCatalogSpecs { architecture, cores, memory_gb, disk_gb }`.
- **Backend (`providers.rs`):** `apply_hetzner_catalog_specs` injects `architecture` into `provisioner_config` JSON and auto-fills `processor_cores`/`memory_amount`/`total_ssd_capacity` from catalog when blank. Wired into create + update handlers.
- **Frontend:** Architecture badge on marketplace cards + detail page. x86/ARM64/All filter pills with live-data gating. URL `?arch=` sync.

## Tests
- 48 hetzner tests (44 original + 4 new TDD)
- 3 new providers tests (inject / preserve-keys / no-overwrite)
- 21 vitest unit tests for architecture helpers
- OpenAPI spec hash unchanged (no endpoint/schema additions)
- 339 e2e pass / 0 fail / 1 skip
- Real-browser visual verification: ARM64 filter pill, arch badge on card, spec row on detail