### PR TITLE
docs: record operator decisions + prod deployment runbook

### DIFF
--- a/docs/OPEN_ISSUES.md
+++ b/docs/OPEN_ISSUES.md
@@ -18,14 +18,22 @@ gh issue list --repo decent-stuff/decent-cloud --state open --json number,title,
 **decent-cloud is "OpenRouter, but for cloud resources"** — a proxy/reselling platform unifying
 many cloud providers behind one common API. Near-term: the operator resells Hetzner. The
 marketplace buy flow (discover → rent → pay → provision → SSH → use → cancel) was verified
-end-to-end against a real Hetzner cx23 VM and merged (PR #479). **Going public is now the gate.**
+end-to-end against a real Hetzner cx23 VM and merged (PR #479). **Operator approved going public
+(2026-08-12). Prod deployment is the remaining step — see PROD-DEPLOY below.**
+
+## Operator decisions (2026-08-12)
+
+| Decision | Rationale |
+|----------|-----------|
+| **EMAIL-GATE: keep as-is in PROD** | Buyers must verify email before renting (anti-Sybil). Dev auto-verifies at account creation; prod unchanged. Closed decision — do not re-ask. |
+| **PROD-LIVE: approved** | Operator authorizes publishing real Hetzner offerings + ongoing spend. Prod already has 2 live offerings (ids 11, 12). Prerequisite: deploy latest `main` to prod (wallet-auto-accept fix). |
+| **TD-1: next session** | dc-agent split (5 M-effort subtasks) deferred to next session per IMPORTANT 9. |
 
 ## Open items
 
 | ID | Description | value [1-10] | effort [S/M/L] | Status / notes |
 |----|-------------|:---:|:---:|----------------|
-| **PROD-LIVE** | Publish real Hetzner-backed offerings to the PROD marketplace + authorize ongoing spend | **10** | **S** | The local path is fully verified + merged (PR #479, commit `05849932`): discover → rent → pay → provision → SSH → cancel against a real cx23 (created ~56s, zero orphans). All creds present (`HETZNER_API_TOKEN_DEV`, `DC_PROD_RESELLER_SEED`). **Blocked only on operator sign-off to go PUBLIC.** Plan: `docs/plans/2026-08-11-marketplace-buy-flow-execution.md`. |
-| **EMAIL-GATE** | Should the email-verification gate block rentals in PROD? | **6** | **S** | Operator decision. The gate currently hard-rejects unverified email at contract-create with an upstream warning (UX shipped). In PROD the tradeoff is fraud/spam prevention vs. buyer friction. Needs an operator call on whether to keep, soften, or remove it for the public launch. |
+| **PROD-DEPLOY** | Deploy latest `main` to prod (k8s `dc-prod` via ArgoCD) | **10** | **M** | **CRITICAL:** Prod is running pre-#479 code — the wallet-auto-accept bug means wallet-paid contracts get stuck at `requested` forever. All fixes from PRs #479-#489 are merged to `main` but NOT deployed. Deploy steps: (1) build image `git.kalaj.org/decent-stuff/decent-cloud-api:<sha>`, (2) bump `third_party/k8s/cluster/apps/decent-cloud/base/dc-api.yaml` image tag, (3) push k8s repo → ArgoCD auto-syncs, (4) verify `https://api.decent-cloud.org/api/v1/stats` shows honest counts (not 17 providers). Prod offerings already exist (ids 11, 12, both `provisioner_type=hetzner`). **Operator action** — k8s repo not accessible from agent container. |
 | **A5** | Concurrent ticket processing in dc-agent (`JoinSet`+`Semaphore`) | **5** | **M** | Bottleneck = serial `for contract in &contracts` at `dc-agent/src/main.rs:1739`. Design complete: codebase is already concurrency-safe (provisioners `Send+Sync`, deterministic VMID, gateway `Arc<Mutex>`); add `max_concurrent_provisioning` config knob with **DEFAULT=1** (behaviorally identical). Ship machinery first, raise N only after operator verifies node headroom. **Deferred — needs operator sign-off on concurrency level.** |
 | **TD-1** | #444 — Large source-file splits (>2700 lines) | **5** | **L** | Deferred → split into M-effort subtasks. `accounts.rs` 2230→973 DONE. `dc-agent/src/main.rs` (3681L) split planned into 5 M-effort waves (S1–S5): `docs/plans/2026-08-12-dc-agent-main-split.md`. `cloud_resources.rs` (2701L) is mostly tests (~1091L prod) — SKIP. `providers.rs` (4082L) + `offerings.rs` (2981L) have no clean decoupled clusters — need dedicated design passes. `spec_snapshot` guard locks byte-identical OpenAPI for future `*Api` splits. Roadmap: `docs/plans/2026-07-25-large-file-splits-444.md`. |
 

--- a/docs/plans/2026-08-12-prod-deployment-runbook.md
+++ b/docs/plans/2026-08-12-prod-deployment-runbook.md
@@ -1,0 +1,124 @@
+# Prod Deployment Runbook — Going Live with Hetzner Resell
+
+**Date:** 2026-08-12
+**Status:** Operator approved. Awaiting prod code deployment.
+**Priority:** #1 — prod buy flow is BROKEN until latest `main` is deployed.
+
+## Context
+
+The marketplace buy flow was verified end-to-end against a real Hetzner cx23 VM and merged
+(PR #479, commit `05849932`). The operator approved going public on 2026-08-12. Prod already has
+2 live Hetzner cloud-resell offerings (ids 11, 12). However, **prod is running code from before
+PR #479** — the wallet-auto-accept bug means wallet-paid contracts get stuck at `requested`
+forever. Deploying latest `main` is the critical prerequisite.
+
+## Prod state (verified 2026-08-12)
+
+- **API:** `https://api.decent-cloud.org` → health 200, environment `prod`
+- **Offerings:** 2 public, in-stock, `provisioner_type=hetzner`:
+  - **id 11** "Hetzner CX22 (resold)" — provider `1ed6136d…` (DC_PROD_RESELLER_PUBKEY),
+    `server_type=cx23`, `location=fsn1`, `image=ubuntu-22.04`, $6.82/mo. Name says CX22 but
+    config is CX23 (correct type, stale name). Missing hardware specs (cores/ram/disk = NULL).
+  - **id 12** "Basic Linux VPS" — provider `1570f163…`, `server_type=cax11` (ARM),
+    `location=fsn1`, `image=ubuntu-24.04`, $7.00/mo. Also missing hardware specs.
+- **Stats:** `total_providers: 17` (inflated — pre-#482 honest-stats fix not deployed).
+- **Code:** pre-#479 (confirmed by inflated stats + no version string in health).
+
+## Steps
+
+### Step 1 — Deploy latest `main` to prod (CRITICAL, operator action)
+
+The agent container cannot reach the k8s repo. The operator must:
+
+```bash
+# In the k8s repo (third_party/k8s or wherever it's cloned):
+# 1. Build + push the API image
+docker build -t git.kalaj.org/decent-stuff/decent-cloud-api:$(git -C /project/decent-cloud/repo rev-parse --short HEAD) /project/decent-cloud/repo
+docker push git.kalaj.org/decent-stuff/decent-cloud-api:$(git -C /project/decent-cloud/repo rev-parse --short HEAD)
+
+# 2. Bump the image tag in the k8s base
+# Edit cluster/apps/decent-cloud/base/dc-api.yaml → image: git.kalaj.org/decent-stuff/decent-cloud-api:<sha>
+
+# 3. Commit + push → ArgoCD auto-syncs
+git add -A && git commit -m "deploy: api $(git -C /project/decent-cloud/repo rev-parse --short HEAD)"
+git push
+
+# 4. Force ArgoCD refresh
+kubectl -n argocd patch application decent-cloud --type=merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"normal"}}}'
+
+# 5. Wait for rollout
+kubectl -n dc-prod rollout status deployment/dc-api --timeout=300s
+
+# 6. Verify
+curl https://api.decent-cloud.org/api/v1/health   # → environment: prod
+curl https://api.decent-cloud.org/api/v1/stats     # → total_providers should be ≤2 (honest stats)
+```
+
+**Alternative:** `python3 cf/deploy.py deploy stage` builds + pushes the stage image. For prod,
+use the same flow against the prod overlay.
+
+### Step 2 — Fix offering details (agent can do this via API)
+
+Offering 11 has a stale name ("CX22" but server_type is cx23) and missing hardware specs.
+After prod code is deployed, update via signed API request as the reseller identity:
+
+```bash
+# Load the reseller identity from the seed
+SEED="$(scripts/dc-secrets get shared/env DC_PROD_RESELLER_SEED)"
+
+# Derive keypair (reuse tools/e2e-real-deployments/src/crypto.js)
+# Sign PUT /api/v1/providers/<pubkey>/offerings/<offering_id> with updated fields:
+#   offer_name: "Hetzner CX23 (resold)"     # was "CX22"
+#   provisioner_config.image: "ubuntu-24.04" # was 22.04
+#   cores: 2, ram_mb: 4096, disk_gb: 40      # was NULL (cx23 = 2 vCPU / 4GB / 40GB)
+```
+
+The exact CX23 specs (from Hetzner API): 2 vCPU, 4.0 GB RAM, 40.0 GB disk, 20 TB traffic.
+
+### Step 3 — Verify the buy flow against prod (after deploy)
+
+```bash
+# 1. Create a test buyer identity
+api-cli identity generate --name prod-test-buyer
+
+# 2. Register the buyer account
+api-cli --api-url https://api.decent-cloud.org --env prod account register --identity prod-test-buyer
+
+# 3. (In prod, email verification is required — the buyer must verify email before renting)
+
+# 4. Rent offering 11
+api-cli --api-url https://api.decent-cloud.org contract create \
+  --identity prod-test-buyer --offering-id 11 \
+  --ssh-pubkey "$(cat ~/.ssh/id_ed25519.pub)"
+
+# 5. Wait for provisioning (~60s for cx23)
+api-cli --api-url https://api.decent-cloud.org contract wait <ID> \
+  --state active --timeout 180 --identity prod-test-buyer
+
+# 6. Verify SSH access
+api-cli --api-url https://api.decent-cloud.org contract get <ID> --identity prod-test-buyer
+# → provisioning_instance_details should have {connection_type: "direct_ssh", public_ip, ssh_port: 22}
+ssh -o StrictHostKeyChecking=no root@<public_ip>
+
+# 7. Cancel (cleanup — MINIMIZE CLOUD SPENDING)
+api-cli --api-url https://api.decent-cloud.org contract cancel <ID> --identity prod-test-buyer
+```
+
+## Known issues in prod (fix after deploy)
+
+1. **Offering 11 name mismatch**: "CX22" in name, cx23 in config. Cosmetic but misleading.
+2. **Missing hardware specs**: Both offerings have `cores/ram_mb/disk_gb = NULL`. Buyers can't
+   see what they're getting. Fix via signed API update.
+3. **Offering 11 image**: `ubuntu-22.04` (not latest). Consider updating to `ubuntu-24.04`.
+4. **Inflated stats**: `total_providers: 17` includes seed/test accounts. The #482 honest-stats
+   fix resolves this once deployed.
+5. **EMAIL-GATE**: Buyers must verify email before renting in prod (operator decided to keep
+   this gate — anti-Sybil). Ensure the email verification flow works end-to-end in prod.
+
+## Blockers
+
+- **k8s repo access**: The agent container cannot reach the k8s repo or deploy via ArgoCD.
+  The operator must perform Step 1 (deploy latest main to prod).
+- **Email verification in prod**: The dev bypass (`is_production_env()`) does NOT apply in prod.
+  Buyers must complete email verification before they can rent. Ensure the email flow (SMTP,
+  MailChannels) is configured in prod.


### PR DESCRIPTION
Records three operator decisions made 2026-08-12:
- **EMAIL-GATE:** keep as-is in prod (buyers must verify email before renting — anti-Sybil)
- **PROD-LIVE:** approved; prod already has 2 live Hetzner offerings; prerequisite = deploy latest main (wallet-auto-accept fix)
- **TD-1:** dc-agent split deferred to next session

Also adds `docs/plans/2026-08-12-prod-deployment-runbook.md` with exact ArgoCD deploy steps.